### PR TITLE
Add EJS view for operator attendance upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,22 @@ CREATE TABLE dispatched_data (
 ```
 
 `incoming_data` stores every addition with timestamp and user while `dispatched_data` tracks quantity sent out along with remarks.
+
+## Operator Attendance Upload
+
+Operators can upload daily attendance JSON files. Create the following table to store calculated working hours:
+
+```sql
+CREATE TABLE operator_attendance (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  punching_id VARCHAR(20) NOT NULL,
+  name VARCHAR(100) NOT NULL,
+  work_date DATE NOT NULL,
+  punch_in TIME NOT NULL,
+  punch_out TIME NOT NULL,
+  hours_worked DECIMAL(5,2) NOT NULL,
+  UNIQUE KEY uniq_punch_date (punching_id, work_date)
+);
+```
+
+`hours_worked` stores the time difference between `punch_in` and `punch_out` in hours. Uploading the same punching ID and date again updates the record.

--- a/app.js
+++ b/app.js
@@ -76,6 +76,7 @@ const washingIN = require('./routes/washingInRoutes');
 const catalogR = require('./routes/catalogupload');
 const hrRoutes = require('./routes/hrRoutes');
 const inventoryRoutes = require('./routes/inventoryRoutes');
+const attendanceRoutes = require('./routes/attendanceRoutes');
 
 // Use Routes
 app.use('/', authRoutes);
@@ -96,6 +97,7 @@ app.use('/', bulkUploadRoutes);
 app.use('/washingin', washingIN);
 app.use('/catalogupload', catalogR);
 app.use('/inventory', inventoryRoutes);
+app.use('/attendance', attendanceRoutes);
 
 app.use('/', hrRoutes);
 // Home Route

--- a/routes/attendanceRoutes.js
+++ b/routes/attendanceRoutes.js
@@ -1,0 +1,64 @@
+const express = require('express');
+const router = express.Router();
+const multer = require('multer');
+const moment = require('moment');
+const { pool } = require('../config/db');
+const { isAuthenticated, isOperator } = require('../middlewares/auth');
+
+const upload = multer();
+
+// GET /attendance - show upload form
+router.get('/', isAuthenticated, isOperator, (req, res) => {
+  res.render('operatorAttendance', { user: req.session.user, logs: null });
+});
+
+// POST /attendance/upload - process JSON attendance
+router.post('/upload', isAuthenticated, isOperator, upload.single('attendanceFile'), async (req, res) => {
+  if (!req.file) {
+    req.flash('error', 'No attendance file uploaded');
+    return res.redirect('/attendance');
+  }
+
+  let records;
+  try {
+    records = JSON.parse(req.file.buffer.toString());
+  } catch (err) {
+    req.flash('error', 'Invalid JSON file');
+    return res.redirect('/attendance');
+  }
+
+  let conn;
+  try {
+    conn = await pool.getConnection();
+    await conn.beginTransaction();
+    for (const emp of records) {
+      const punchingId = emp.punchingId;
+      const name = emp.name;
+      if (!Array.isArray(emp.attendance)) continue;
+      for (const att of emp.attendance) {
+        const date = att.date;
+        const punchIn = att.punchIn;
+        const punchOut = att.punchOut;
+        const minutes = moment(punchOut, 'HH:mm').diff(moment(punchIn, 'HH:mm'), 'minutes');
+        const hoursWorked = (minutes / 60).toFixed(2);
+        await conn.query(
+          `INSERT INTO operator_attendance (punching_id, name, work_date, punch_in, punch_out, hours_worked)
+           VALUES (?, ?, ?, ?, ?, ?)
+           ON DUPLICATE KEY UPDATE punch_in=VALUES(punch_in), punch_out=VALUES(punch_out), hours_worked=VALUES(hours_worked)`,
+          [punchingId, name, date, punchIn, punchOut, hoursWorked]
+        );
+      }
+    }
+    await conn.commit();
+    req.flash('success', 'Attendance uploaded');
+  } catch (err) {
+    if (conn) await conn.rollback();
+    console.error('Error processing attendance:', err);
+    req.flash('error', 'Could not process attendance');
+  } finally {
+    if (conn) conn.release();
+  }
+  res.redirect('/attendance');
+});
+
+module.exports = router;

--- a/views/operatorAttendance.ejs
+++ b/views/operatorAttendance.ejs
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Operator Attendance Upload</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container-fluid">
+      <span class="navbar-brand">Operator Attendance</span>
+      <div class="ms-auto">
+        <% if (user) { %>
+          <span class="navbar-text me-3">Welcome, <strong><%= user.username %></strong></span>
+          <a href="/logout" class="btn btn-outline-light">Logout</a>
+        <% } %>
+      </div>
+    </div>
+  </nav>
+
+  <div class="container mt-4">
+    <%- include('partials/flashMessages') %>
+    <div class="card">
+      <div class="card-body">
+        <h4 class="card-title mb-3">Upload Attendance JSON</h4>
+        <form action="/attendance/upload" method="POST" enctype="multipart/form-data">
+          <div class="mb-3">
+            <input type="file" name="attendanceFile" accept=".json" class="form-control" required>
+          </div>
+          <button type="submit" class="btn btn-primary">Upload</button>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `operatorAttendance.ejs` with a basic JSON upload form
- render the new view from `/attendance` route

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68513ecb80108320ba8fe4dbe9f92c7f