### PR TITLE
Add department management on attendance page

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,18 @@ CREATE TABLE operator_attendance (
 ```
 
 `hours_worked` stores the time difference between `punch_in` and `punch_out` in hours. Uploading the same punching ID and date again updates the record.
+
+## Department Management
+
+Create a table to store production departments and assign each a supervisor:
+
+```sql
+CREATE TABLE departments (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL UNIQUE,
+  supervisor_id INT UNIQUE,
+  FOREIGN KEY (supervisor_id) REFERENCES users(id)
+);
+```
+
+`supervisor_id` references a user with the role `supervisor`. Each supervisor can only manage one department. Operators can create new departments and change their assigned supervisor from the dashboard.

--- a/views/operatorAttendance.ejs
+++ b/views/operatorAttendance.ejs
@@ -31,6 +31,60 @@
         </form>
       </div>
     </div>
+
+    <div class="card mt-4">
+      <div class="card-body">
+        <h4 class="card-title mb-3">Manage Departments</h4>
+
+        <form class="row g-3 mb-4" method="POST" action="/attendance/department/create">
+          <div class="col-md-5">
+            <input type="text" class="form-control" name="name" placeholder="Department name" required>
+          </div>
+          <div class="col-md-5">
+            <select class="form-select" name="supervisor_id">
+              <option value="">Select Supervisor</option>
+              <% supervisors.forEach(function(s){ %>
+                <option value="<%= s.id %>"><%= s.username %></option>
+              <% }) %>
+            </select>
+          </div>
+          <div class="col-md-2">
+            <button type="submit" class="btn btn-primary w-100">Create</button>
+          </div>
+        </form>
+
+        <% if (departments && departments.length) { %>
+          <table class="table table-bordered">
+            <thead class="table-light">
+              <tr>
+                <th>Name</th>
+                <th>Supervisor</th>
+                <th>Change Supervisor</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% departments.forEach(function(d){ %>
+                <tr>
+                  <td><%= d.name %></td>
+                  <td><%= d.supervisor || 'Unassigned' %></td>
+                  <td>
+                    <form class="d-flex" method="POST" action="/attendance/department/<%= d.id %>/update-supervisor">
+                      <select class="form-select form-select-sm me-2" name="supervisor_id" required>
+                        <option value="">Select</option>
+                        <% supervisors.forEach(function(s){ %>
+                          <option value="<%= s.id %>" <%= d.supervisor_id==s.id ? 'selected' : '' %>><%= s.username %></option>
+                        <% }) %>
+                      </select>
+                      <button class="btn btn-sm btn-primary" type="submit">Update</button>
+                    </form>
+                  </td>
+                </tr>
+              <% }) %>
+            </tbody>
+          </table>
+        <% } %>
+      </div>
+    </div>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- allow operator to manage departments from attendance page
- add DB table instructions for departments

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68514dbcc4d0832098d372e689a37cee