### PR TITLE
Add employee-linked attendance uploads and supervisor view

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,23 +154,25 @@ CREATE TABLE dispatched_data (
 
 ## Operator Attendance Upload
 
-Operators can upload daily attendance JSON files. Create the following table to store calculated working hours:
+Operators can upload daily attendance JSON files. Create the following table to store calculated working hours and link each record to an employee:
 
 ```sql
 CREATE TABLE operator_attendance (
   id INT AUTO_INCREMENT PRIMARY KEY,
+  employee_id INT NOT NULL,
   punching_id VARCHAR(20) NOT NULL,
   name VARCHAR(100) NOT NULL,
   work_date DATE NOT NULL,
   punch_in TIME NOT NULL,
   punch_out TIME NOT NULL,
-hours_worked DECIMAL(5,2) NOT NULL,
-  UNIQUE KEY uniq_punch_date (punching_id, work_date)
+  hours_worked DECIMAL(5,2) NOT NULL,
+  UNIQUE KEY uniq_emp_date (employee_id, work_date),
+  FOREIGN KEY (employee_id) REFERENCES employees(id)
 );
 ```
 
 `hours_worked` stores the time difference between `punch_in` and `punch_out` in hours. Uploading the same punching ID and date again updates the record.
-Attendance files must be named using the pattern `departmentName+supervisorName.json` (e.g. `cutting+john.json`). The server validates that the supervisor is assigned to that department.
+Attendance files must be named using the pattern `departmentName+supervisorName+userId.json` (e.g. `cutting+john+5.json`). The server validates that the supervisor with that ID is assigned to the department.
 
 ## Department Management
 

--- a/views/supervisorEmployeeAttendance.ejs
+++ b/views/supervisorEmployeeAttendance.ejs
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title><%= employee.name %> Attendance</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-dark navbar-expand-lg">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="/supervisor/employees">Back</a>
+    <div class="ms-auto">
+      <a href="/logout" class="btn btn-outline-light btn-sm">Logout</a>
+    </div>
+  </div>
+</nav>
+<div class="container mt-4">
+  <h4 class="mb-3">Attendance - <%= employee.name %></h4>
+  <div class="table-responsive">
+    <table class="table table-bordered">
+      <thead class="table-light">
+        <tr>
+          <th>Date</th>
+          <th>Punch In</th>
+          <th>Punch Out</th>
+          <th>Hours Worked</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% attendance.forEach(function(a){ %>
+          <tr>
+            <td><%= new Date(a.work_date).toISOString().split('T')[0] %></td>
+            <td><%= a.punch_in %></td>
+            <td><%= a.punch_out %></td>
+            <td><%= a.hours_worked %></td>
+          </tr>
+        <% }) %>
+      </tbody>
+    </table>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/supervisorEmployees.ejs
+++ b/views/supervisorEmployees.ejs
@@ -55,6 +55,7 @@
           <th>Salary Type</th>
           <th>Salary</th>
           <th>Working Hours</th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -65,6 +66,9 @@
             <td><%= emp.salary_type %></td>
             <td><%= emp.salary %></td>
             <td><%= emp.working_hours %></td>
+            <td>
+              <a href="/supervisor/employees/<%= emp.id %>/attendance" class="btn btn-sm btn-info">View Attendance</a>
+            </td>
           </tr>
         <% }) %>
       </tbody>


### PR DESCRIPTION
## Summary
- link operator attendance records to employees
- require attendance filenames of the form `dept+supervisor+id.json`
- allow supervisors to view attendance for their employees

## Testing
- `npm --version`
- `node --version`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851615371f08320842a70d908e51145