### PR TITLE
Add store admin inventory dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ CREATE TABLE dispatched_data (
 
 `incoming_data` stores every addition with timestamp and user while `dispatched_data` tracks quantity sent out along with remarks.
 
+Create a `store_admin` role in the `roles` table to allow managing the list of goods. Users with this role can add new items (description, size and unit) from the Store Admin dashboard. Newly created items automatically appear in the store inventory pages.
+
 ## Operator Attendance Upload
 
 Operators can upload daily attendance JSON files. Create the following table to store calculated working hours and link each record to an employee:

--- a/app.js
+++ b/app.js
@@ -74,6 +74,7 @@ const jeansAssemblyRoutes = require('./routes/jeansAssemblyRoutes.js');
 const editCuttingLotRoutes = require("./routes/editcuttinglots.js");
 const washingIN = require('./routes/washingInRoutes');
 const catalogR = require('./routes/catalogupload');
+const storeAdminRoutes = require('./routes/storeAdminRoutes');
 const hrRoutes = require('./routes/hrRoutes');
 const inventoryRoutes = require('./routes/inventoryRoutes');
 const attendanceRoutes = require('./routes/attendanceRoutes');
@@ -98,6 +99,7 @@ app.use('/', bulkUploadRoutes);
 app.use('/washingin', washingIN);
 app.use('/catalogupload', catalogR);
 app.use('/inventory', inventoryRoutes);
+app.use('/store-admin', storeAdminRoutes);
 app.use('/attendance', attendanceRoutes);
 app.use('/supervisor', supervisorRoutes);
 

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -116,6 +116,10 @@ function isStoreEmployee(req, res, next) {
     return hasRole('store_employee')(req, res, next);
 }
 
+function isStoreAdmin(req, res, next) {
+    return hasRole('store_admin')(req, res, next);
+}
+
 module.exports = {
     isAuthenticated,
     isAdmin,
@@ -132,5 +136,6 @@ module.exports = {
     isPaymentAuthoriser,
     isWashingInMaster,
     isCatalogUpload,
-    isStoreEmployee
+    isStoreEmployee,
+    isStoreAdmin
 };

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -79,9 +79,12 @@ router.post('/login', async (req, res) => {
       case 'jeans_assembly':
           res.redirect('/jeansassemblydashboard');
           break;
-        case 'washing_in':            // New case for washing in
-          res.redirect('/washingin');
-          break;
+      case 'washing_in':            // New case for washing in
+        res.redirect('/washingin');
+        break;
+      case 'store_admin':
+        res.redirect('/store-admin/dashboard');
+        break;
       case 'store_employee':
         res.redirect('/inventory/dashboard');
         break;

--- a/routes/storeAdminRoutes.js
+++ b/routes/storeAdminRoutes.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/db');
+const { isAuthenticated, isStoreAdmin } = require('../middlewares/auth');
+
+// GET dashboard for store admin
+router.get('/dashboard', isAuthenticated, isStoreAdmin, async (req, res) => {
+  try {
+    const [goods] = await pool.query('SELECT * FROM goods_inventory ORDER BY description_of_goods, size');
+    const [dispatched] = await pool.query(`SELECT d.*, g.description_of_goods, g.size, g.unit
+                                            FROM dispatched_data d
+                                            JOIN goods_inventory g ON d.goods_id = g.id
+                                            ORDER BY d.dispatched_at DESC LIMIT 50`);
+    res.render('storeAdminDashboard', { user: req.session.user, goods, dispatched });
+  } catch (err) {
+    console.error('Error loading store admin dashboard:', err);
+    req.flash('error', 'Could not load dashboard');
+    res.redirect('/');
+  }
+});
+
+// POST create new goods item
+router.post('/create', isAuthenticated, isStoreAdmin, async (req, res) => {
+  const { description, size, unit } = req.body;
+  if (!description || !size || !unit) {
+    req.flash('error', 'All fields are required');
+    return res.redirect('/store-admin/dashboard');
+  }
+  try {
+    await pool.query('INSERT INTO goods_inventory (description_of_goods, size, unit) VALUES (?, ?, ?)',
+      [description, size, unit]);
+    req.flash('success', 'Item created');
+    res.redirect('/store-admin/dashboard');
+  } catch (err) {
+    console.error('Error creating item:', err);
+    req.flash('error', 'Could not create item');
+    res.redirect('/store-admin/dashboard');
+  }
+});
+
+module.exports = router;

--- a/views/storeAdminDashboard.ejs
+++ b/views/storeAdminDashboard.ejs
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Store Admin Dashboard</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
+  <style>
+    .low-stock { background-color: #f8d7da; }
+    .select2-container{ width:100%!important; }
+  </style>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="#">Store Admin</a>
+    <div class="ms-auto">
+      <a href="/logout" class="btn btn-outline-light btn-sm">Logout</a>
+    </div>
+  </div>
+</nav>
+<div class="container my-4">
+  <%- include('partials/flashMessages') %>
+  <ul class="nav nav-tabs" id="invTabs" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="create-tab" data-bs-toggle="tab" data-bs-target="#createTab" type="button" role="tab">Create Item</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="add-tab" data-bs-toggle="tab" data-bs-target="#addTab" type="button" role="tab">Add Quantity</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="dispatch-tab" data-bs-toggle="tab" data-bs-target="#dispatchTab" type="button" role="tab">Dispatch Goods</button>
+    </li>
+  </ul>
+  <div class="tab-content mt-3">
+    <div class="tab-pane fade show active" id="createTab" role="tabpanel">
+      <form action="/store-admin/create" method="POST" class="row g-3">
+        <div class="col-md-5">
+          <label class="form-label">Description</label>
+          <input type="text" name="description" class="form-control" required>
+        </div>
+        <div class="col-md-3">
+          <label class="form-label">Size</label>
+          <input type="text" name="size" class="form-control" required>
+        </div>
+        <div class="col-md-2">
+          <label class="form-label">Unit</label>
+          <select name="unit" class="form-select" required>
+            <option value="PCS">PCS</option>
+            <option value="ROLL">ROLL</option>
+          </select>
+        </div>
+        <div class="col-md-2 align-self-end">
+          <button type="submit" class="btn btn-success">Create</button>
+        </div>
+      </form>
+    </div>
+    <div class="tab-pane fade" id="addTab" role="tabpanel">
+      <form action="/inventory/add" method="POST" class="row g-3">
+        <div class="col-md-6">
+          <label class="form-label">Item</label>
+          <select id="addGoods" name="goods_id" class="form-select" required>
+            <% goods.forEach(g => { %>
+              <option value="<%= g.id %>"><%= g.description_of_goods %> - <%= g.size %> - <%= g.unit %></option>
+            <% }) %>
+          </select>
+        </div>
+        <div class="col-md-3">
+          <label class="form-label">Quantity</label>
+          <input type="number" name="quantity" class="form-control" required min="1">
+        </div>
+        <div class="col-md-3 align-self-end">
+          <button type="submit" class="btn btn-primary">Add</button>
+        </div>
+      </form>
+    </div>
+    <div class="tab-pane fade" id="dispatchTab" role="tabpanel">
+      <form action="/inventory/dispatch" method="POST" class="row g-3">
+        <div class="col-md-6">
+          <label class="form-label">Item</label>
+          <select id="dispatchGoods" name="goods_id" class="form-select" required>
+            <% goods.forEach(g => { %>
+              <option value="<%= g.id %>"><%= g.description_of_goods %> - <%= g.size %> - <%= g.unit %></option>
+            <% }) %>
+          </select>
+        </div>
+        <div class="col-md-3">
+          <label class="form-label">Quantity</label>
+          <input type="number" name="quantity" class="form-control" required min="1">
+        </div>
+        <div class="col-md-3">
+          <label class="form-label">Remark</label>
+          <input type="text" name="remark" class="form-control">
+        </div>
+        <div class="col-12">
+          <button type="submit" class="btn btn-warning">Dispatch</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <h4 class="mt-4">Current Inventory</h4>
+  <div class="table-responsive">
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>Description</th>
+          <th>Size</th>
+          <th>Unit</th>
+          <th>Qty</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% goods.forEach(g => { %>
+          <tr class="<%= g.qty == 100 ? 'low-stock' : '' %>">
+            <td><%= g.description_of_goods %></td>
+            <td><%= g.size %></td>
+            <td><%= g.unit %></td>
+            <td><%= g.qty %></td>
+          </tr>
+        <% }) %>
+      </tbody>
+    </table>
+  </div>
+
+  <h4 class="mt-4">Recent Dispatches</h4>
+  <div class="table-responsive">
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>Item</th>
+          <th>Qty</th>
+          <th>Remark</th>
+          <th>Date</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% dispatched.forEach(d => { %>
+          <tr>
+            <td><%= d.description_of_goods %> - <%= d.size %> <%= d.unit %></td>
+            <td><%= d.quantity %></td>
+            <td><%= d.remark || '' %></td>
+            <td><%= d.dispatched_at.toISOString().slice(0,16).replace('T',' ') %></td>
+          </tr>
+        <% }) %>
+      </tbody>
+    </table>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+<script>
+$(function(){
+  $('#addGoods').select2({ placeholder:'Select item', minimumResultsForSearch:0 });
+  $('#dispatchGoods').select2({ placeholder:'Select item', minimumResultsForSearch:0 });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `store_admin` role checks
- create store admin dashboard with item creation and searchable dropdowns
- add routes to manage store inventory
- wire new dashboard into app and login flow
- document new role in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853e279dcf48320b0da7beba76d0888