### PR TITLE
Add operator pendency dashboard

### DIFF
--- a/routes/operatorRoutes.js
+++ b/routes/operatorRoutes.js
@@ -459,6 +459,113 @@ router.get("/dashboard/api/leftovers", isAuthenticated, isOperator, async (req, 
   }
 });
 
+async function fetchPendencyRows(dept, searchLike, offset, limit) {
+  let query = "";
+  const params = [searchLike, offset, limit];
+  if (dept === "assembly") {
+    query = `
+      SELECT ja.id AS assignment_id, sd.lot_no, u.username,
+             ja.assigned_pieces AS assigned,
+             COALESCE(SUM(jd.total_pieces),0) AS completed,
+             ja.assigned_pieces - COALESCE(SUM(jd.total_pieces),0) AS pending
+        FROM jeans_assembly_assignments ja
+        JOIN stitching_data sd ON ja.stitching_assignment_id = sd.id
+        JOIN users u ON ja.user_id = u.id
+        LEFT JOIN jeans_assembly_data jd ON jd.assignment_id = ja.id
+       WHERE sd.lot_no LIKE ?
+       GROUP BY ja.id
+       ORDER BY ja.assigned_on DESC
+       LIMIT ?, ?`;
+  } else if (dept === "washing") {
+    query = `
+      SELECT wa.id AS assignment_id, jd.lot_no, u.username,
+             wa.assigned_pieces AS assigned,
+             COALESCE(SUM(wd.total_pieces),0) AS completed,
+             wa.assigned_pieces - COALESCE(SUM(wd.total_pieces),0) AS pending
+        FROM washing_assignments wa
+        JOIN jeans_assembly_data jd ON wa.jeans_assembly_assignment_id = jd.id
+        JOIN users u ON wa.user_id = u.id
+        LEFT JOIN washing_data wd ON wd.washing_assignment_id = wa.id
+       WHERE jd.lot_no LIKE ?
+       GROUP BY wa.id
+       ORDER BY wa.assigned_on DESC
+       LIMIT ?, ?`;
+  } else {
+    query = `
+      SELECT sa.id AS assignment_id, c.lot_no, u.username,
+             sa.assigned_pieces AS assigned,
+             COALESCE(SUM(sd.total_pieces),0) AS completed,
+             sa.assigned_pieces - COALESCE(SUM(sd.total_pieces),0) AS pending
+        FROM stitching_assignments sa
+        JOIN cutting_lots c ON sa.cutting_lot_id = c.id
+        JOIN users u ON sa.user_id = u.id
+        LEFT JOIN stitching_data sd ON sd.stitching_assignment_id = sa.id
+       WHERE c.lot_no LIKE ?
+       GROUP BY sa.id
+       ORDER BY sa.assigned_on DESC
+       LIMIT ?, ?`;
+  }
+  const [rows] = await pool.query(query, params);
+  return rows;
+}
+
+router.get("/dashboard/api/pendency", isAuthenticated, isOperator, async (req, res) => {
+  try {
+    const { dept = "stitching", page = 1, size = 50, search = "" } = req.query;
+    const offset = (parseInt(page) - 1) * parseInt(size);
+    const rows = await fetchPendencyRows(dept, `%${search}%`, offset, parseInt(size));
+    return res.json({ data: rows });
+  } catch (err) {
+    console.error("Error in /dashboard/api/pendency:", err);
+    return res.status(500).json({ error: "Server error" });
+  }
+});
+
+router.get("/dashboard/pendency/download", isAuthenticated, isOperator, async (req, res) => {
+  try {
+    const { dept = "stitching", search = "" } = req.query;
+    const rows = await fetchPendencyRows(dept, `%${search}%`, 0, 10000);
+
+    const workbook = new ExcelJS.Workbook();
+    const sheet = workbook.addWorksheet("Pendency");
+    sheet.columns = [
+      { header: "Lot No", key: "lot_no", width: 15 },
+      { header: "Operator", key: "username", width: 20 },
+      { header: "Assigned", key: "assigned", width: 12 },
+      { header: "Completed", key: "completed", width: 12 },
+      { header: "Pending", key: "pending", width: 12 }
+    ];
+    rows.forEach(r => sheet.addRow(r));
+    res.setHeader("Content-Disposition", `attachment; filename="${dept}_pendency.xlsx"`);
+    res.setHeader("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+    await workbook.xlsx.write(res);
+    res.end();
+  } catch (err) {
+    console.error("Error in /dashboard/pendency/download:", err);
+    return res.status(500).send("Server error");
+  }
+});
+
+router.get("/dashboard/api/lot", isAuthenticated, isOperator, async (req, res) => {
+  try {
+    const { lotNo } = req.query;
+    if (!lotNo) return res.status(400).json({ error: "lotNo required" });
+    const [[lot]] = await pool.query(
+      `SELECT id, lot_no, sku, fabric_type, total_pieces FROM cutting_lots WHERE lot_no = ? LIMIT 1`,
+      [lotNo]
+    );
+    if (!lot) return res.status(404).json({ error: "Lot not found" });
+    const [sizes] = await pool.query(
+      `SELECT size_label, total_pieces FROM cutting_lot_sizes WHERE cutting_lot_id = ?`,
+      [lot.id]
+    );
+    return res.json({ lot, sizes });
+  } catch (err) {
+    console.error("Error in /dashboard/api/lot:", err);
+    return res.status(500).json({ error: "Server error" });
+  }
+});
+
 /**************************************************
  * 4) CSV/Excel leftover exports – same as your code
  **************************************************/

--- a/views/operatorDashboard.ejs
+++ b/views/operatorDashboard.ejs
@@ -59,7 +59,10 @@
     #sidebar a.active, .offcanvas-body a.active {
       background-color: #0d6efd;
     }
-    /* Persistent sidebar for md and up */
+    .nav-cards { display:flex; flex-wrap:wrap; gap:1rem; }
+    .nav-card { background:#fff; border-radius:6px; padding:1rem; flex:1 0 180px; text-align:center; box-shadow:0 1px 3px rgba(0,0,0,0.1); text-decoration:none; color:inherit; }
+    .nav-card:hover { background:#0d6efd; color:#fff; }
+  /* Persistent sidebar for md and up */
     @media (min-width: 768px) {
       #sidebar {
         position: fixed;
@@ -173,6 +176,21 @@
     </div>
   </div>
 
+  <!-- Lot Details Modal -->
+  <div class="modal fade" id="lotDetailsModal" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Lot Details</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+        </div>
+        <div class="modal-body" id="lotDetailsBody">
+          Loading...
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Persistent Sidebar for Desktop -->
   <div id="sidebar" class="d-none d-md-block">
     <h5 class="mb-3 text-white">Navigation</h5>
@@ -227,6 +245,32 @@
             <div class="stat-value"><%= userCount %></div>
           </div>
         </div>
+      </div>
+    </div>
+
+    <!-- Quick Links -->
+    <div class="container mb-4">
+      <div class="nav-cards">
+        <a href="/operator/editcuttinglots" class="nav-card" data-bs-toggle="tooltip" title="Edit existing lots">
+          <i class="bi bi-pencil-square fs-3"></i>
+          <div>Edit Lots</div>
+        </a>
+        <a href="/operator/dashboard/download-all-lots" class="nav-card" data-bs-toggle="tooltip" title="Download all lots">
+          <i class="bi bi-cloud-arrow-down fs-3"></i>
+          <div>Export All</div>
+        </a>
+        <a href="/search-dashboard" class="nav-card" data-bs-toggle="tooltip" title="Search inventory">
+          <i class="bi bi-search fs-3"></i>
+          <div>Search</div>
+        </a>
+        <a href="/assign-to-washing" class="nav-card" data-bs-toggle="tooltip" title="Assign Washing">
+          <i class="bi bi-arrow-right-circle fs-3"></i>
+          <div>Washing</div>
+        </a>
+        <a href="/operator/dashboard/pic-report" class="nav-card" data-bs-toggle="tooltip" title="Per piece report">
+          <i class="bi bi-file-earmark-check fs-3"></i>
+          <div>PIC Report</div>
+        </a>
       </div>
     </div>
 
@@ -427,6 +471,29 @@
       </div>
     </div>
 
+    <!-- Pendency Panel -->
+    <div class="data-panel mt-4">
+      <div class="panel-header d-flex justify-content-between align-items-center">
+        <div><i class="bi bi-hourglass-split"></i> Pendency</div>
+        <div>
+          <a href="/operator/dashboard/pendency/download?dept=stitching" class="me-2" data-bs-toggle="tooltip" title="Download Stitching">
+            <i class="bi bi-download"></i> Stitch
+          </a>
+          <a href="/operator/dashboard/pendency/download?dept=assembly" class="me-2" data-bs-toggle="tooltip" title="Download Assembly">
+            <i class="bi bi-download"></i> Assembly
+          </a>
+          <a href="/operator/dashboard/pendency/download?dept=washing" data-bs-toggle="tooltip" title="Download Washing">
+            <i class="bi bi-download"></i> Washing
+          </a>
+        </div>
+      </div>
+      <div class="panel-body">
+        <input id="pendencySearchInput" type="text" class="form-control mb-2" placeholder="Search pendency...">
+        <div id="pendencyTable" style="height:400px;"></div>
+        <button id="loadMorePendency" class="btn btn-primary mt-2">Load More</button>
+      </div>
+    </div>
+
     <!-- Edit Kit Modals -->
     <% Object.keys(lotDetails).forEach(function(kitNumber){ 
          var kitData = lotDetails[kitNumber];
@@ -610,7 +677,7 @@
     document.querySelectorAll('input[name="lotType"]').forEach(radio => {
       radio.addEventListener("change", updateLeftoverFilter);
     });
-    document.getElementById("columnChooser").addEventListener("click", function() {
+  document.getElementById("columnChooser").addEventListener("click", function() {
       const columns = leftoverTable.getColumns();
       const container = document.getElementById("columnChooserContent");
       container.innerHTML = "";
@@ -644,6 +711,66 @@
       const modal = new bootstrap.Modal(document.getElementById("columnChooserModal"));
       modal.show();
     });
+
+    /*************************************************
+     * Pendency Table
+     *************************************************/
+    let pendencyPage = 1;
+    let pendencySearch = '';
+    let pendencyData = [];
+    const pendColumns = [
+      { title: "Lot", field: "lot_no", formatter: lotLinkFormatter, width: 120 },
+      { title: "Operator", field: "username", width: 150 },
+      { title: "Assigned", field: "assigned", width: 100 },
+      { title: "Completed", field: "completed", width: 100 },
+      { title: "Pending", field: "pending", width: 100 }
+    ];
+    function lotLinkFormatter(cell){
+      const val = cell.getValue();
+      return `<a href="#" class="lot-link" data-lot="${val}">${val}</a>`;
+    }
+    const pendTable = new Tabulator("#pendencyTable", {
+      layout: "fitColumns",
+      movableColumns: true,
+      pagination: "local",
+      paginationSize: 50,
+      columns: pendColumns,
+      placeholder: "No Data"
+    });
+    async function loadPendencyPage(pageNum){
+      try {
+        const resp = await fetch(`/operator/dashboard/api/pendency?page=${pageNum}&search=${encodeURIComponent(pendencySearch)}`);
+        if(!resp.ok) throw new Error(resp.statusText);
+        const json = await resp.json();
+        if(pageNum===1){ pendencyData = json.data; pendTable.setData(pendencyData); }
+        else { pendencyData = pendencyData.concat(json.data); pendTable.replaceData(pendencyData); }
+      } catch(err){ console.error('Error loading pendency:', err); }
+    }
+    loadPendencyPage(1);
+    document.getElementById('loadMorePendency').addEventListener('click',()=>{pendencyPage++;loadPendencyPage(pendencyPage);});
+    document.getElementById('pendencySearchInput').addEventListener('keyup',function(){pendencySearch=this.value;pendencyPage=1;loadPendencyPage(1);});
+
+    document.getElementById('pendencyTable').addEventListener('click',async function(e){
+      const link = e.target.closest('.lot-link');
+      if(link){
+        e.preventDefault();
+        const lot = link.getAttribute('data-lot');
+        const resp = await fetch(`/operator/dashboard/api/lot?lotNo=${encodeURIComponent(lot)}`);
+        if(resp.ok){
+          const json = await resp.json();
+          const body = document.getElementById('lotDetailsBody');
+          body.innerHTML = `<p><strong>Lot:</strong> ${json.lot.lot_no}</p>`+
+            `<p><strong>SKU:</strong> ${json.lot.sku}</p>`+
+            `<p><strong>Fabric:</strong> ${json.lot.fabric_type}</p>`+
+            `<p><strong>Total Pieces:</strong> ${json.lot.total_pieces}</p>`;
+          new bootstrap.Modal(document.getElementById('lotDetailsModal')).show();
+        }
+      }
+    });
+
+    // Enable Bootstrap tooltips
+    const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+    tooltipTriggerList.forEach(el => new bootstrap.Tooltip(el));
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add pendency API and Excel download routes
- provide lazy loaded pendency table and lot detail modal on operator dashboard
- add quick-link cards and tooltips for easier navigation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685af368f8c88320b34b0fe33cb3ca90