### PR TITLE
Add department management for operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,24 @@ CREATE TABLE dispatched_data (
 
 Create a `store_admin` role in the `roles` table to allow managing the list of goods. Users with this role can add new items (description, size and unit) from the Store Admin dashboard. Newly created items automatically appear in the store inventory pages.
 
+## Department & Supervisor Tables
+
+Use the following tables to manage departments and the supervisors assigned to them:
+
+```sql
+CREATE TABLE departments (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL UNIQUE
+);
+
+CREATE TABLE department_supervisors (
+  department_id INT NOT NULL,
+  user_id INT NOT NULL,
+  PRIMARY KEY (department_id, user_id),
+  FOREIGN KEY (department_id) REFERENCES departments(id),
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+```
+
+Operators can create departments and assign `supervisor` users to them from the Department Management screen.
+

--- a/app.js
+++ b/app.js
@@ -77,6 +77,7 @@ const catalogR = require('./routes/catalogupload');
 const storeAdminRoutes = require('./routes/storeAdminRoutes');
 const hrRoutes = require('./routes/hrRoutes');
 const inventoryRoutes = require('./routes/inventoryRoutes');
+const departmentMgmtRoutes = require('./routes/departmentMgmtRoutes');
 
 // Use Routes
 app.use('/', authRoutes);
@@ -93,6 +94,7 @@ app.use('/', searchRoutes);
 app.use('/assign-to-washing', assigntowashingRoutes);
 app.use('/jeansassemblydashboard', jeansAssemblyRoutes);
 app.use("/operator", editCuttingLotRoutes);
+app.use('/operator', departmentMgmtRoutes);
 app.use('/', bulkUploadRoutes);
 app.use('/washingin', washingIN);
 app.use('/catalogupload', catalogR);

--- a/routes/departmentMgmtRoutes.js
+++ b/routes/departmentMgmtRoutes.js
@@ -1,0 +1,81 @@
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/db');
+const { isAuthenticated, isOperator } = require('../middlewares/auth');
+
+// GET /operator/departments - list departments and supervisors
+router.get('/departments', isAuthenticated, isOperator, async (req, res) => {
+  try {
+    const [deptRows] = await pool.query(
+      `SELECT d.id, d.name,
+              GROUP_CONCAT(u.username ORDER BY u.username SEPARATOR ', ') AS supervisors
+         FROM departments d
+         LEFT JOIN department_supervisors ds ON d.id = ds.department_id
+         LEFT JOIN users u ON ds.user_id = u.id
+         GROUP BY d.id
+         ORDER BY d.name`
+    );
+
+    const [supervisors] = await pool.query(
+      `SELECT u.id, u.username
+         FROM users u
+         JOIN roles r ON u.role_id = r.id
+        WHERE r.name = 'supervisor' AND u.is_active = 1
+        ORDER BY u.username`
+    );
+
+    res.render('operatorDepartments', {
+      user: req.session.user,
+      departments: deptRows,
+      supervisors
+    });
+  } catch (err) {
+    console.error('Error loading departments:', err);
+    req.flash('error', 'Failed to load departments');
+    res.redirect('/operator/dashboard');
+  }
+});
+
+// POST /operator/departments - create a department
+router.post('/departments', isAuthenticated, isOperator, async (req, res) => {
+  const { name } = req.body;
+  if (!name) {
+    req.flash('error', 'Department name required');
+    return res.redirect('/operator/departments');
+  }
+  try {
+    await pool.query('INSERT INTO departments (name) VALUES (?)', [name]);
+    req.flash('success', 'Department created');
+    res.redirect('/operator/departments');
+  } catch (err) {
+    console.error('Error creating department:', err);
+    req.flash('error', 'Error creating department');
+    res.redirect('/operator/departments');
+  }
+});
+
+// POST /operator/departments/:id/assign - assign supervisor to department
+router.post('/departments/:id/assign', isAuthenticated, isOperator, async (req, res) => {
+  const deptId = req.params.id;
+  const { user_id } = req.body;
+  if (!deptId || !user_id) {
+    req.flash('error', 'Invalid supervisor assignment');
+    return res.redirect('/operator/departments');
+  }
+  try {
+    await pool.query(
+      `INSERT INTO department_supervisors (department_id, user_id)
+       VALUES (?, ?)
+       ON DUPLICATE KEY UPDATE department_id = department_id`,
+      [deptId, user_id]
+    );
+    req.flash('success', 'Supervisor assigned');
+    res.redirect('/operator/departments');
+  } catch (err) {
+    console.error('Error assigning supervisor:', err);
+    req.flash('error', 'Error assigning supervisor');
+    res.redirect('/operator/departments');
+  }
+});
+
+module.exports = router;

--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Department Management</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-dark">
+  <div class="container-fluid">
+    <span class="navbar-brand">Department Management</span>
+    <div class="ms-auto">
+      <a href="/logout" class="btn btn-outline-light btn-sm">Logout</a>
+    </div>
+  </div>
+</nav>
+<div class="container my-4">
+  <%- include('partials/flashMessages') %>
+  <h4>Create Department</h4>
+  <form action="/operator/departments" method="POST" class="row g-3 mb-4">
+    <div class="col-md-6">
+      <input type="text" name="name" class="form-control" placeholder="Department name" required>
+    </div>
+    <div class="col-md-2">
+      <button type="submit" class="btn btn-primary">Create</button>
+    </div>
+  </form>
+  <h4>Existing Departments</h4>
+  <table class="table table-bordered">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Supervisors</th>
+        <th>Assign Supervisor</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% departments.forEach(function(d) { %>
+        <tr>
+          <td><%= d.name %></td>
+          <td><%= d.supervisors || '' %></td>
+          <td>
+            <form action="/operator/departments/<%= d.id %>/assign" method="POST" class="d-flex">
+              <select name="user_id" class="form-select form-select-sm me-2" required>
+                <% supervisors.forEach(function(u){ %>
+                  <option value="<%= u.id %>"><%= u.username %></option>
+                <% }) %>
+              </select>
+              <button class="btn btn-sm btn-secondary">Assign</button>
+            </form>
+          </td>
+        </tr>
+      <% }) %>
+    </tbody>
+  </table>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow operators to create departments and assign supervisors
- display a management screen at `/operator/departments`
- register new router
- document required tables for departments

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e5c8c875c8320ba1b30abcc3a31d7