### PR TITLE
Add supervisor employee management

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,25 @@ CREATE TABLE department_supervisors (
 
 Operators can create departments and assign `supervisor` users to them from the Department Management screen.
 
+
+## Supervisor Employees
+
+To let supervisors manage their own employees, create the following table:
+
+```sql
+CREATE TABLE employees (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  supervisor_id INT NOT NULL,
+  punching_id VARCHAR(100) NOT NULL,
+  name VARCHAR(100) NOT NULL,
+  phone_number VARCHAR(20),
+  salary DECIMAL(10,2) NOT NULL,
+  salary_type ENUM('dihadi', 'monthly') NOT NULL,
+  date_of_joining DATE NOT NULL,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  FOREIGN KEY (supervisor_id) REFERENCES users(id)
+);
+```
+
+Each supervisor can add, view and activate/deactivate only the employees that belong to them.
+

--- a/app.js
+++ b/app.js
@@ -78,6 +78,7 @@ const storeAdminRoutes = require('./routes/storeAdminRoutes');
 const hrRoutes = require('./routes/hrRoutes');
 const inventoryRoutes = require('./routes/inventoryRoutes');
 const departmentMgmtRoutes = require('./routes/departmentMgmtRoutes');
+const employeeRoutes = require('./routes/employeeRoutes');
 
 // Use Routes
 app.use('/', authRoutes);
@@ -100,6 +101,7 @@ app.use('/washingin', washingIN);
 app.use('/catalogupload', catalogR);
 app.use('/inventory', inventoryRoutes);
 app.use('/store-admin', storeAdminRoutes);
+app.use('/supervisor', employeeRoutes);
 
 app.use('/', hrRoutes);
 // Home Route

--- a/routes/employeeRoutes.js
+++ b/routes/employeeRoutes.js
@@ -1,0 +1,73 @@
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/db');
+const { isAuthenticated, isSupervisor } = require('../middlewares/auth');
+
+// Show employee dashboard for a supervisor
+router.get('/employees', isAuthenticated, isSupervisor, async (req, res) => {
+  try {
+    const userId = req.session.user.id;
+    const [deptRows] = await pool.query(
+      `SELECT d.name FROM departments d
+       JOIN department_supervisors ds ON ds.department_id = d.id
+       WHERE ds.user_id = ? LIMIT 1`,
+      [userId]
+    );
+    const department = deptRows.length ? deptRows[0].name : 'N/A';
+
+    const [employees] = await pool.query(
+      'SELECT * FROM employees WHERE supervisor_id = ?',
+      [userId]
+    );
+
+    res.render('supervisorEmployees', {
+      user: req.session.user,
+      department,
+      employees
+    });
+  } catch (err) {
+    console.error('Error loading employees:', err);
+    req.flash('error', 'Failed to load employees');
+    res.redirect('/dashboard');
+  }
+});
+
+// Create a new employee for the logged in supervisor
+router.post('/employees', isAuthenticated, isSupervisor, async (req, res) => {
+  const { punching_id, name, phone_number, salary, salary_type, date_of_joining } = req.body;
+  try {
+    await pool.query(
+      `INSERT INTO employees
+        (supervisor_id, punching_id, name, phone_number, salary, salary_type, date_of_joining, is_active)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 1)`,
+      [req.session.user.id, punching_id, name, phone_number, salary, salary_type, date_of_joining]
+    );
+    req.flash('success', 'Employee created');
+    res.redirect('/supervisor/employees');
+  } catch (err) {
+    console.error('Error creating employee:', err);
+    req.flash('error', 'Failed to create employee');
+    res.redirect('/supervisor/employees');
+  }
+});
+
+// Toggle employee active status
+router.post('/employees/:id/toggle', isAuthenticated, isSupervisor, async (req, res) => {
+  const id = req.params.id;
+  try {
+    await pool.query(
+      `UPDATE employees
+          SET is_active = NOT is_active
+        WHERE id = ? AND supervisor_id = ?`,
+      [id, req.session.user.id]
+    );
+    req.flash('success', 'Employee status updated');
+    res.redirect('/supervisor/employees');
+  } catch (err) {
+    console.error('Error toggling employee:', err);
+    req.flash('error', 'Failed to update employee');
+    res.redirect('/supervisor/employees');
+  }
+});
+
+module.exports = router;

--- a/views/supervisorEmployees.ejs
+++ b/views/supervisorEmployees.ejs
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>My Employees</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-dark">
+  <div class="container-fluid">
+    <span class="navbar-brand">Employees - <%= department %></span>
+    <div class="ms-auto">
+      <a href="/logout" class="btn btn-outline-light btn-sm">Logout</a>
+    </div>
+  </div>
+</nav>
+<div class="container my-4">
+  <%- include('partials/flashMessages') %>
+  <h4>Add Employee</h4>
+  <form action="/supervisor/employees" method="POST" class="row g-3 mb-4">
+    <div class="col-md-3">
+      <label class="form-label">Punching ID</label>
+      <input type="text" name="punching_id" class="form-control" required>
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">Name</label>
+      <input type="text" name="name" class="form-control" required>
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">Phone</label>
+      <input type="text" name="phone_number" class="form-control">
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">Date of Joining</label>
+      <input type="date" name="date_of_joining" class="form-control" required>
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">Salary</label>
+      <input type="number" step="0.01" name="salary" class="form-control" required>
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">Salary Type</label>
+      <select name="salary_type" class="form-select" required>
+        <option value="dihadi">Dihadi</option>
+        <option value="monthly">Monthly</option>
+      </select>
+    </div>
+    <div class="col-md-2 align-self-end">
+      <button type="submit" class="btn btn-success">Create</button>
+    </div>
+  </form>
+  <h4>My Employees</h4>
+  <div class="table-responsive">
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>Punch ID</th>
+          <th>Name</th>
+          <th>Phone</th>
+          <th>Salary</th>
+          <th>Type</th>
+          <th>Joined</th>
+          <th>Status</th>
+          <th>Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% employees.forEach(emp => { %>
+          <tr>
+            <td><%= emp.punching_id %></td>
+            <td><%= emp.name %></td>
+            <td><%= emp.phone_number || '' %></td>
+            <td><%= emp.salary %></td>
+            <td><%= emp.salary_type %></td>
+            <td><%= emp.date_of_joining.toISOString().slice(0,10) %></td>
+            <td><%= emp.is_active ? 'Active' : 'Inactive' %></td>
+            <td>
+              <form action="/supervisor/employees/<%= emp.id %>/toggle" method="POST">
+                <button class="btn btn-sm <%= emp.is_active ? 'btn-danger' : 'btn-success' %>">
+                  <%= emp.is_active ? 'Deactivate' : 'Activate' %>
+                </button>
+              </form>
+            </td>
+          </tr>
+        <% }) %>
+      </tbody>
+    </table>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow supervisors to manage employees
- mount new employee routes
- document `employees` table schema

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_685e792e176c8320aad491c3081d2eeb