### PR TITLE
Add attendance and salary tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,45 @@ CREATE TABLE employee_advances (
 ```
 
 Debits represent losses caused by the employee, while advances are company funds lent to the employee. Supervisors can add entries for any of their own employees.
+
+## Attendance & Salary
+
+Add tables to track daily attendance and calculate monthly salaries:
+
+```sql
+CREATE TABLE employee_attendance (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  employee_id INT NOT NULL,
+  date DATE NOT NULL,
+  punch_in TIME,
+  punch_out TIME,
+  status ENUM('present','absent','one punch only') DEFAULT 'present',
+  UNIQUE KEY unique_att (employee_id, date),
+  FOREIGN KEY (employee_id) REFERENCES employees(id)
+);
+
+CREATE TABLE employee_salaries (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  employee_id INT NOT NULL,
+  month CHAR(7) NOT NULL, -- YYYY-MM
+  gross DECIMAL(10,2) NOT NULL,
+  deduction DECIMAL(10,2) NOT NULL,
+  net DECIMAL(10,2) NOT NULL,
+  created_at DATETIME NOT NULL,
+  UNIQUE KEY unique_salary (employee_id, month),
+  FOREIGN KEY (employee_id) REFERENCES employees(id)
+);
+```
+
+Update the `employees` table to store each worker's allotted hours per day:
+
+```sql
+ALTER TABLE employees ADD COLUMN allotted_hours DECIMAL(4,2) NOT NULL DEFAULT 0;
+```
+
+Operators can upload JSON attendance files. After upload each employee's punches
+are stored in `employee_attendance` and a monthly record is calculated in
+`employee_salaries`.
+
+A summary page lists each supervisor with their active employee count and total
+monthly salary.

--- a/app.js
+++ b/app.js
@@ -79,6 +79,7 @@ const hrRoutes = require('./routes/hrRoutes');
 const inventoryRoutes = require('./routes/inventoryRoutes');
 const departmentMgmtRoutes = require('./routes/departmentMgmtRoutes');
 const employeeRoutes = require('./routes/employeeRoutes');
+const salaryRoutes = require('./routes/salaryRoutes');
 
 // Use Routes
 app.use('/', authRoutes);
@@ -102,6 +103,7 @@ app.use('/catalogupload', catalogR);
 app.use('/inventory', inventoryRoutes);
 app.use('/store-admin', storeAdminRoutes);
 app.use('/supervisor', employeeRoutes);
+app.use('/', salaryRoutes);
 
 app.use('/', hrRoutes);
 // Home Route

--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -1,0 +1,25 @@
+const moment = require('moment');
+
+async function calculateSalaryForMonth(conn, employeeId, month) {
+  const [[emp]] = await conn.query('SELECT salary, salary_type FROM employees WHERE id = ?', [employeeId]);
+  if (!emp) return;
+  const [attendance] = await conn.query(
+    'SELECT status FROM employee_attendance WHERE employee_id = ? AND DATE_FORMAT(date, "%Y-%m") = ?',
+    [employeeId, month]
+  );
+  const daysInMonth = moment(month + '-01').daysInMonth();
+  const dailyRate = parseFloat(emp.salary) / daysInMonth;
+  let absent = 0;
+  attendance.forEach(a => { if (a.status === 'absent') absent++; });
+  const gross = parseFloat(emp.salary);
+  const deduction = absent * dailyRate;
+  const net = gross - deduction;
+  await conn.query(
+    `INSERT INTO employee_salaries (employee_id, month, gross, deduction, net, created_at)
+     VALUES (?, ?, ?, ?, ?, NOW())
+     ON DUPLICATE KEY UPDATE gross=VALUES(gross), deduction=VALUES(deduction), net=VALUES(net)`,
+    [employeeId, month, gross, deduction, net]
+  );
+}
+
+module.exports = { calculateSalaryForMonth };

--- a/routes/salaryRoutes.js
+++ b/routes/salaryRoutes.js
@@ -1,0 +1,112 @@
+const express = require('express');
+const router = express.Router();
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+const moment = require('moment');
+const { pool } = require('../config/db');
+const { isAuthenticated, isOperator, isSupervisor } = require('../middlewares/auth');
+const { calculateSalaryForMonth } = require('../helpers/salaryCalculator');
+
+// Configure upload for JSON files
+const storage = multer.diskStorage({
+  destination: function(req, file, cb) {
+    cb(null, 'uploads/');
+  },
+  filename: function(req, file, cb) {
+    const newName = Date.now() + path.extname(file.originalname);
+    cb(null, newName);
+  }
+});
+const upload = multer({ storage });
+
+// GET form to upload attendance JSON
+router.get('/salary/upload', isAuthenticated, isOperator, (req, res) => {
+  res.render('attendanceUpload', { user: req.session.user });
+});
+
+// POST process uploaded attendance JSON
+router.post('/salary/upload', isAuthenticated, isOperator, upload.single('attFile'), async (req, res) => {
+  const file = req.file;
+  if (!file) {
+    req.flash('error', 'No file uploaded');
+    return res.redirect('/operator/salary/upload');
+  }
+  let data;
+  try {
+    const jsonStr = fs.readFileSync(file.path, 'utf8');
+    data = JSON.parse(jsonStr);
+  } catch (err) {
+    console.error('Failed to parse JSON:', err);
+    req.flash('error', 'Invalid JSON');
+    return res.redirect('/operator/salary/upload');
+  }
+  const conn = await pool.getConnection();
+  try {
+    await conn.beginTransaction();
+    for (const emp of data) {
+      const [empRows] = await conn.query('SELECT id, salary, salary_type FROM employees WHERE punching_id = ? AND name = ? LIMIT 1', [emp.punchingId, emp.name]);
+      if (!empRows.length) continue;
+      const employee = empRows[0];
+      for (const att of emp.attendance) {
+        await conn.query(
+          `INSERT INTO employee_attendance (employee_id, date, punch_in, punch_out, status)
+           VALUES (?, ?, ?, ?, ?)
+           ON DUPLICATE KEY UPDATE punch_in = VALUES(punch_in), punch_out = VALUES(punch_out), status = VALUES(status)`,
+          [employee.id, att.date, att.punchIn || null, att.punchOut || null, att.status || 'present']
+        );
+      }
+      const month = moment(data[0].attendance[0].date).format('YYYY-MM');
+      await calculateSalaryForMonth(conn, employee.id, month);
+    }
+    await conn.commit();
+    req.flash('success', 'Attendance uploaded');
+  } catch (err) {
+    await conn.rollback();
+    console.error('Error processing attendance:', err);
+    req.flash('error', 'Failed to process attendance');
+  } finally {
+    conn.release();
+  }
+  res.redirect('/operator/salary/upload');
+});
+
+// View salary summary for operator
+router.get('/salaries', isAuthenticated, isOperator, async (req, res) => {
+  try {
+    const [rows] = await pool.query(`
+      SELECT u.name AS supervisor_name, u.id AS supervisor_id,
+             COUNT(e.id) AS employee_count,
+             SUM(CASE WHEN e.is_active = 1 THEN e.salary ELSE 0 END) AS total_salary
+        FROM users u
+        JOIN employees e ON e.supervisor_id = u.id
+       GROUP BY u.id`);
+    res.render('operatorSalaries', { user: req.session.user, summary: rows });
+  } catch (err) {
+    console.error('Error loading salary summary:', err);
+    req.flash('error', 'Could not load salary summary');
+    res.redirect('/dashboard');
+  }
+});
+
+// Supervisor view of employee salary
+router.get('/employees/:id/salary', isAuthenticated, isSupervisor, async (req, res) => {
+  const empId = req.params.id;
+  const month = req.query.month || moment().format('YYYY-MM');
+  try {
+    const [[emp]] = await pool.query('SELECT * FROM employees WHERE id = ? AND supervisor_id = ?', [empId, req.session.user.id]);
+    if (!emp) {
+      req.flash('error', 'Employee not found');
+      return res.redirect('/supervisor/employees');
+    }
+    const [attendance] = await pool.query('SELECT * FROM employee_attendance WHERE employee_id = ? AND DATE_FORMAT(date, "%Y-%m") = ? ORDER BY date', [empId, month]);
+    const [[salary]] = await pool.query('SELECT * FROM employee_salaries WHERE employee_id = ? AND month = ? LIMIT 1', [empId, month]);
+    res.render('employeeSalary', { user: req.session.user, employee: emp, attendance, salary, month });
+  } catch (err) {
+    console.error('Error loading salary view:', err);
+    req.flash('error', 'Failed to load salary');
+    res.redirect('/supervisor/employees');
+  }
+});
+
+module.exports = router;

--- a/views/attendanceUpload.ejs
+++ b/views/attendanceUpload.ejs
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Upload Attendance</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-dark">
+  <div class="container-fluid">
+    <span class="navbar-brand">Upload Attendance</span>
+    <div class="ms-auto">
+      <a href="/logout" class="btn btn-outline-light btn-sm">Logout</a>
+    </div>
+  </div>
+</nav>
+<div class="container my-4">
+  <%- include('partials/flashMessages') %>
+  <form action="/operator/salary/upload" method="POST" enctype="multipart/form-data" class="row g-3">
+    <div class="col-md-6">
+      <input type="file" name="attFile" accept="application/json" class="form-control" required>
+    </div>
+    <div class="col-md-2">
+      <button type="submit" class="btn btn-primary">Upload</button>
+    </div>
+  </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/employeeSalary.ejs
+++ b/views/employeeSalary.ejs
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Employee Salary</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-dark">
+  <div class="container-fluid">
+    <span class="navbar-brand"><%= employee.name %> - Salary</span>
+    <div class="ms-auto">
+      <a href="/supervisor/employees" class="btn btn-outline-light btn-sm me-2">Back</a>
+      <a href="/logout" class="btn btn-outline-light btn-sm">Logout</a>
+    </div>
+  </div>
+</nav>
+<div class="container my-4">
+  <%- include('partials/flashMessages') %>
+  <h5>Month: <%= month %></h5>
+  <table class="table table-bordered">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Status</th>
+        <th>Punch In</th>
+        <th>Punch Out</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% attendance.forEach(a => { %>
+        <tr>
+          <td><%= a.date.toISOString().slice(0,10) %></td>
+          <td><%= a.status %></td>
+          <td><%= a.punch_in || '' %></td>
+          <td><%= a.punch_out || '' %></td>
+        </tr>
+      <% }) %>
+    </tbody>
+  </table>
+  <% if (salary) { %>
+    <h6>Gross: <%= salary.gross %> | Deduction: <%= salary.deduction %> | Net: <%= salary.net %></h6>
+  <% } else { %>
+    <p>No salary record for this month.</p>
+  <% } %>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/operatorSalaries.ejs
+++ b/views/operatorSalaries.ejs
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Salary Summary</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-dark">
+  <div class="container-fluid">
+    <span class="navbar-brand">Salary Summary</span>
+    <div class="ms-auto">
+      <a href="/logout" class="btn btn-outline-light btn-sm">Logout</a>
+    </div>
+  </div>
+</nav>
+<div class="container my-4">
+  <%- include('partials/flashMessages') %>
+  <table class="table table-bordered">
+    <thead>
+      <tr>
+        <th>Supervisor</th>
+        <th>Active Employees</th>
+        <th>Total Salary</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% summary.forEach(s => { %>
+        <tr>
+          <td><%= s.supervisor_name %></td>
+          <td><%= s.employee_count %></td>
+          <td><%= s.total_salary %></td>
+        </tr>
+      <% }) %>
+    </tbody>
+  </table>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/supervisorEmployees.ejs
+++ b/views/supervisorEmployees.ejs
@@ -82,6 +82,7 @@
                 </button>
               </form>
               <a href="/supervisor/employees/<%= emp.id %>/details" class="btn btn-sm btn-primary">Details</a>
+              <a href="/employees/<%= emp.id %>/salary" class="btn btn-sm btn-secondary">Salary</a>
             </td>
           </tr>
         <% }) %>


### PR DESCRIPTION
## Summary
- track per-employee attendance and salary
- upload monthly attendance JSON and compute salary
- show salary summary for operator
- allow supervisors to view employee salary

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e93eeb32883209bad5ed3c50a8362