### PR TITLE
Fix salary dashboard route and improve attendance upload validation

### DIFF
--- a/views/operatorDashboard.ejs
+++ b/views/operatorDashboard.ejs
@@ -166,7 +166,7 @@
       <a href="#" onclick="window.print()"><i class="bi bi-printer"></i> Print</a>
       <a href="/assign-to-washing"><i class="bi bi-arrow-right-circle"></i> Washing</a>
       <a href="/operator/dashboard/pic-report"><i class="bi bi-file-earmark-check"></i>Per Piece Report</a>
-      <a href="/operator/departments?view=salary"><i class="bi bi-wallet2"></i> Salaries</a>
+      <a href="/operator/departments"><i class="bi bi-wallet2"></i> Salaries</a>
       <div class="mt-3">
         <h6>Pendency Reports</h6>
         <a href="/operator/pendency-report/stitching"><i class="bi bi-journal-arrow-down"></i> Stitching</a>
@@ -203,7 +203,7 @@
     <a href="#" onclick="window.print()"><i class="bi bi-printer"></i> Print</a>
     <a href="/assign-to-washing"><i class="bi bi-arrow-right-circle"></i> Washing</a>
     <a href="/operator/dashboard/pic-report"><i class="bi bi-file-earmark-check"></i>Per Piece Report</a>
-    <a href="/operator/departments?view=salary"><i class="bi bi-wallet2"></i> Salaries</a>
+    <a href="/operator/departments"><i class="bi bi-wallet2"></i> Salaries</a>
     <div class="mt-3">
       <h6 class="text-white">Pendency Reports</h6>
       <a href="/operator/pendency-report/stitching"><i class="bi bi-journal-arrow-down"></i> Stitching</a>
@@ -273,7 +273,7 @@
           <i class="bi bi-file-earmark-check fs-3"></i>
           <div>PIC Report</div>
         </a>
-        <a href="/operator/departments?view=salary" class="nav-card" data-bs-toggle="tooltip" title="Manage salaries">
+        <a href="/operator/departments" class="nav-card" data-bs-toggle="tooltip" title="Manage salaries">
           <i class="bi bi-wallet2 fs-3"></i>
           <div>Salaries</div>
         </a>


### PR DESCRIPTION
## Summary
- show salary management on `/operator/departments` by default
- validate uploaded attendance filenames and keep files in memory
- update dashboard links to new salary URL

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f800e77208320b2317c4354e46fd0