### PR TITLE
Add designation field and enhance employee pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ CREATE TABLE employees (
   supervisor_id INT NOT NULL,
   punching_id VARCHAR(100) NOT NULL,
   name VARCHAR(100) NOT NULL,
+  designation VARCHAR(100),
   phone_number VARCHAR(20),
   salary DECIMAL(10,2) NOT NULL,
   salary_type ENUM('dihadi', 'monthly') NOT NULL,
@@ -191,6 +192,12 @@ Update the `employees` table to store each worker's allotted hours per day:
 
 ```sql
 ALTER TABLE employees ADD COLUMN allotted_hours DECIMAL(4,2) NOT NULL DEFAULT 0;
+```
+
+Add a `designation` field for each employee:
+
+```sql
+ALTER TABLE employees ADD COLUMN designation VARCHAR(100) AFTER name;
 ```
 
 Operators can upload JSON attendance files. After upload each employee's punches

--- a/routes/employeeRoutes.js
+++ b/routes/employeeRoutes.js
@@ -35,13 +35,13 @@ router.get('/employees', isAuthenticated, isSupervisor, async (req, res) => {
 
 // Create a new employee for the logged in supervisor
 router.post('/employees', isAuthenticated, isSupervisor, async (req, res) => {
-  const { punching_id, name, phone_number, salary, salary_type, allotted_hours, date_of_joining } = req.body;
+  const { punching_id, name, designation, phone_number, salary, salary_type, allotted_hours, date_of_joining } = req.body;
   try {
     await pool.query(
       `INSERT INTO employees
-        (supervisor_id, punching_id, name, phone_number, salary, salary_type, allotted_hours, date_of_joining, is_active)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1)`,
-      [req.session.user.id, punching_id, name, phone_number, salary, salary_type, allotted_hours, date_of_joining]
+        (supervisor_id, punching_id, name, designation, phone_number, salary, salary_type, allotted_hours, date_of_joining, is_active)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)`,
+      [req.session.user.id, punching_id, name, designation, phone_number, salary, salary_type, allotted_hours, date_of_joining]
     );
     req.flash('success', 'Employee created');
     res.redirect('/supervisor/employees');

--- a/views/employeeDetails.ejs
+++ b/views/employeeDetails.ejs
@@ -5,18 +5,23 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Employee Details</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Roboto', sans-serif; font-size: 0.95rem; }
+  </style>
 </head>
 <body>
 <nav class="navbar navbar-dark bg-dark">
   <div class="container-fluid">
-    <span class="navbar-brand"><%= employee.name %> - Details</span>
+    <span class="navbar-brand"><%= employee.name %> (<%= employee.designation || 'N/A' %>) - Details</span>
     <div class="ms-auto">
       <a href="/supervisor/employees" class="btn btn-outline-light btn-sm me-2">Back</a>
       <a href="/logout" class="btn btn-outline-light btn-sm">Logout</a>
     </div>
   </div>
 </nav>
-<div class="container my-4">
+<div class="container-fluid my-4">
   <%- include('partials/flashMessages') %>
 
   <h5>Leave Balance: <%= leaveBalance %> days</h5>
@@ -119,5 +124,9 @@
   </table>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  const tooltipTriggerList = Array.from(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+  tooltipTriggerList.forEach(t => new bootstrap.Tooltip(t));
+</script>
 </body>
 </html>

--- a/views/employeeSalary.ejs
+++ b/views/employeeSalary.ejs
@@ -4,18 +4,23 @@
   <meta charset="UTF-8">
   <title>Employee Salary</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Roboto', sans-serif; font-size: 0.95rem; }
+  </style>
 </head>
 <body>
 <nav class="navbar navbar-dark bg-dark">
   <div class="container-fluid">
-    <span class="navbar-brand"><%= employee.name %> - Salary</span>
+    <span class="navbar-brand"><%= employee.name %> (<%= employee.designation || 'N/A' %>) - Salary</span>
     <div class="ms-auto">
       <a href="/supervisor/employees" class="btn btn-outline-light btn-sm me-2">Back</a>
       <a href="/logout" class="btn btn-outline-light btn-sm">Logout</a>
     </div>
   </div>
 </nav>
-<div class="container my-4">
+<div class="container-fluid my-4">
   <%- include('partials/flashMessages') %>
   <form method="GET" action="/employees/<%= employee.id %>/salary" class="row g-2 mb-3">
     <div class="col-auto">
@@ -53,5 +58,9 @@
   <% } %>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  const tooltipTriggerList = Array.from(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+  tooltipTriggerList.forEach(t => new bootstrap.Tooltip(t));
+</script>
 </body>
 </html>

--- a/views/supervisorEmployees.ejs
+++ b/views/supervisorEmployees.ejs
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>My Employees</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Roboto', sans-serif; font-size: 0.95rem; }
+  </style>
 </head>
 <body>
 <nav class="navbar navbar-dark bg-dark">
@@ -15,21 +20,25 @@
     </div>
   </div>
 </nav>
-<div class="container my-4">
+<div class="container-fluid my-4">
   <%- include('partials/flashMessages') %>
   <h4>Add Employee</h4>
   <form action="/supervisor/employees" method="POST" class="row g-3 mb-4">
     <div class="col-md-3">
       <label class="form-label">Punching ID</label>
-      <input type="text" name="punching_id" class="form-control" required>
+      <input type="text" name="punching_id" class="form-control" placeholder="Punch ID" required>
     </div>
     <div class="col-md-3">
       <label class="form-label">Name</label>
-      <input type="text" name="name" class="form-control" required>
+      <input type="text" name="name" class="form-control" placeholder="Full name" required>
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">Designation</label>
+      <input type="text" name="designation" class="form-control" placeholder="e.g. Tailor" data-bs-toggle="tooltip" title="Employee role">
     </div>
     <div class="col-md-3">
       <label class="form-label">Phone</label>
-      <input type="text" name="phone_number" class="form-control">
+      <input type="text" name="phone_number" class="form-control" placeholder="Phone number">
     </div>
     <div class="col-md-3">
       <label class="form-label">Date of Joining</label>
@@ -37,7 +46,7 @@
     </div>
     <div class="col-md-3">
       <label class="form-label">Salary</label>
-      <input type="number" step="0.01" name="salary" class="form-control" required>
+      <input type="number" step="0.01" name="salary" class="form-control" placeholder="Amount" required>
     </div>
     <div class="col-md-3">
       <label class="form-label">Salary Type</label>
@@ -48,10 +57,10 @@
     </div>
     <div class="col-md-3">
       <label class="form-label">Allotted Hours</label>
-      <input type="number" step="0.1" name="allotted_hours" class="form-control" required>
+      <input type="number" step="0.1" name="allotted_hours" class="form-control" placeholder="8" required>
     </div>
     <div class="col-md-2 align-self-end">
-      <button type="submit" class="btn btn-success">Create</button>
+      <button type="submit" class="btn btn-success"><i class="fas fa-plus me-1"></i> Create</button>
     </div>
   </form>
   <h4>My Employees</h4>
@@ -61,6 +70,7 @@
         <tr>
           <th>Punch ID</th>
           <th>Name</th>
+          <th>Designation</th>
           <th>Phone</th>
           <th>Salary</th>
           <th>Type</th>
@@ -75,6 +85,7 @@
           <tr>
             <td><%= emp.punching_id %></td>
             <td><%= emp.name %></td>
+            <td><%= emp.designation || '' %></td>
             <td><%= emp.phone_number || '' %></td>
             <td><%= emp.salary %></td>
             <td><%= emp.salary_type %></td>
@@ -97,5 +108,9 @@
   </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  const tooltipTriggerList = Array.from(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+  tooltipTriggerList.forEach(t => new bootstrap.Tooltip(t));
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend `employees` table to include `designation`
- document new DB schema and alter command
- store `designation` when creating employees
- update employee list view with designation column and responsive UI
- display designation on employee detail and salary pages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f8e9649548320a3324ffb7a00bd0a