### PR TITLE
Update attendance status logic and salary deduction

### DIFF
--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -10,7 +10,9 @@ async function calculateSalaryForMonth(conn, employeeId, month) {
   const daysInMonth = moment(month + '-01').daysInMonth();
   const dailyRate = parseFloat(emp.salary) / daysInMonth;
   let absent = 0;
-  attendance.forEach(a => { if (a.status === 'absent') absent++; });
+  attendance.forEach(a => {
+    if (a.status === 'absent' || a.status === 'one punch only') absent++;
+  });
   const gross = parseFloat(emp.salary);
   const deduction = absent * dailyRate;
   const net = gross - deduction;


### PR DESCRIPTION
## Summary
- fix attendance edit route to update status based on punches
- treat `one punch only` as an absent day in salary calculations

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685f9846a684832091d11fe0933b8ae4