### PR TITLE
Add night shift upload feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,3 +248,24 @@ CREATE TABLE attendance_edit_logs (
 ```
 
 Operators can modify punch times from the dashboard, but once three rows exist in `attendance_edit_logs` for a given employee no further edits are allowed. Every update also recalculates the employee's salary for that month.
+## Night Shift Uploads
+
+Operators can upload a monthly Excel sheet listing the night shifts worked by employees. Create a table to store these uploads:
+
+```sql
+CREATE TABLE employee_nights (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  employee_id INT NOT NULL,
+  supervisor_name VARCHAR(100) NOT NULL,
+  supervisor_department VARCHAR(100) NOT NULL,
+  punching_id VARCHAR(100) NOT NULL,
+  employee_name VARCHAR(100) NOT NULL,
+  nights INT NOT NULL,
+  month CHAR(7) NOT NULL,
+  UNIQUE KEY uniq_night (employee_id, month),
+  FOREIGN KEY (employee_id) REFERENCES employees(id)
+);
+```
+
+Uploading a sheet increases the employee's salary by `nights * (salary / days_in_month)` for the current month. Duplicate uploads for the same employee and month are ignored.
+

--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -27,6 +27,13 @@ async function calculateSalaryForMonth(conn, employeeId, month) {
       if (a.status === 'absent' || a.status === 'one punch only') absent++;
     }
   });
+
+  const [nightRows] = await conn.query(
+    'SELECT COALESCE(SUM(nights),0) AS total_nights FROM employee_nights WHERE employee_id = ? AND month = ?',
+    [employeeId, month]
+  );
+  const nightPay = (parseFloat(nightRows[0].total_nights) || 0) * dailyRate;
+  extraPay += nightPay;
   const gross = parseFloat(emp.salary) + extraPay;
   const deduction = absent * dailyRate;
   const net = gross - deduction;

--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -64,6 +64,14 @@
         <button type="submit" class="btn btn-primary">Upload</button>
       </div>
     </form>
+    <form action="/salary/upload-nights" method="POST" enctype="multipart/form-data" class="row g-3 mb-3">
+      <div class="col-md-6">
+        <input type="file" name="excelFile" accept=".xlsx,.xls" class="form-control" required>
+      </div>
+      <div class="col-md-2">
+        <button type="submit" class="btn btn-primary">Upload Nights</button>
+      </div>
+    </form>
     <div class="table-responsive">
       <table class="table table-bordered">
         <thead>


### PR DESCRIPTION
## Summary
- document new `employee_nights` table
- factor night bonuses into salary calculator
- allow operators to upload monthly night-shift Excel files
- expose the upload form on the departments dashboard

## Testing
- `node -c helpers/salaryCalculator.js`
- `node -c routes/salaryRoutes.js`


------
https://chatgpt.com/codex/tasks/task_e_685fbadf3e6c832086512664a3eb25c0