### PR TITLE
Add night template download

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,3 +248,27 @@ CREATE TABLE attendance_edit_logs (
 ```
 
 Operators can modify punch times from the dashboard, but once three rows exist in `attendance_edit_logs` for a given employee no further edits are allowed. Every update also recalculates the employee's salary for that month.
+## Night Shift Uploads
+
+Operators can upload a monthly Excel sheet listing the night shifts worked by employees. Create a table to store these uploads:
+
+```sql
+CREATE TABLE employee_nights (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  employee_id INT NOT NULL,
+  supervisor_name VARCHAR(100) NOT NULL,
+  supervisor_department VARCHAR(100) NOT NULL,
+  punching_id VARCHAR(100) NOT NULL,
+  employee_name VARCHAR(100) NOT NULL,
+  nights INT NOT NULL,
+  month CHAR(7) NOT NULL,
+  UNIQUE KEY uniq_night (employee_id, month),
+  FOREIGN KEY (employee_id) REFERENCES employees(id)
+);
+```
+
+Uploading a sheet increases the employee's salary by `nights * (salary / days_in_month)` for the current month. Duplicate uploads for the same employee and month are ignored.
+
+Operators can download an Excel template for this upload via the `/salary/night-template` route. The file includes the following columns:
+`supervisorname`, `supervisordepartment`, `punchingid`, `name`, `nights`, `month`.
+

--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -27,6 +27,13 @@ async function calculateSalaryForMonth(conn, employeeId, month) {
       if (a.status === 'absent' || a.status === 'one punch only') absent++;
     }
   });
+
+  const [nightRows] = await conn.query(
+    'SELECT COALESCE(SUM(nights),0) AS total_nights FROM employee_nights WHERE employee_id = ? AND month = ?',
+    [employeeId, month]
+  );
+  const nightPay = (parseFloat(nightRows[0].total_nights) || 0) * dailyRate;
+  extraPay += nightPay;
   const gross = parseFloat(emp.salary) + extraPay;
   const deduction = absent * dailyRate;
   const net = gross - deduction;

--- a/routes/salaryRoutes.js
+++ b/routes/salaryRoutes.js
@@ -7,6 +7,8 @@ const { pool } = require('../config/db');
 const { isAuthenticated, isOperator, isSupervisor } = require('../middlewares/auth');
 const { calculateSalaryForMonth } = require('../helpers/salaryCalculator');
 const { validateAttendanceFilename } = require('../helpers/attendanceFilenameValidator');
+const XLSX = require('xlsx');
+const ExcelJS = require('exceljs');
 
 // Configure upload for JSON files in memory
 const upload = multer({ storage: multer.memoryStorage() });
@@ -70,6 +72,86 @@ router.post('/salary/upload', isAuthenticated, isOperator, upload.single('attFil
   }
 
   res.redirect('/operator/departments');
+});
+
+// POST night shift Excel upload
+router.post('/salary/upload-nights', isAuthenticated, isOperator, upload.single('excelFile'), async (req, res) => {
+  const file = req.file;
+  if (!file) {
+    req.flash('error', 'No file uploaded');
+    return res.redirect('/operator/departments');
+  }
+
+  let rows;
+  try {
+    const wb = XLSX.read(file.buffer, { type: 'buffer' });
+    const ws = wb.Sheets[wb.SheetNames[0]];
+    rows = XLSX.utils.sheet_to_json(ws, { defval: '' });
+  } catch (err) {
+    console.error('Failed to parse Excel:', err);
+    req.flash('error', 'Invalid Excel file');
+    return res.redirect('/operator/departments');
+  }
+
+  const monthNow = moment().format('YYYY-MM');
+  const conn = await pool.getConnection();
+  try {
+    await conn.beginTransaction();
+    let uploadedCount = 0;
+    for (const r of rows) {
+      const month = String(r.month || r.Month || '').trim();
+      if (month !== monthNow) continue;
+      const punchingId = String(r.punchingid || r.punchingId || r.punching_id || '').trim();
+      const name = String(r.name || r.employee_name || r.EmployeeName || '').trim();
+      const nights = parseInt(r.nights || r.Nights || r.night || 0, 10);
+      if (!punchingId || !name || !nights) continue;
+      const [empRows] = await conn.query('SELECT id, salary FROM employees WHERE punching_id = ? AND name = ? LIMIT 1', [punchingId, name]);
+      if (!empRows.length) continue;
+      const empId = empRows[0].id;
+      const [existing] = await conn.query('SELECT id FROM employee_nights WHERE employee_id = ? AND month = ? LIMIT 1', [empId, monthNow]);
+      if (existing.length) continue;
+      await conn.query(
+        'INSERT INTO employee_nights (employee_id, supervisor_name, supervisor_department, punching_id, employee_name, nights, month) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        [empId, r.supervisorname || r.supervisor_name || '', r.supervisordepartment || r.department || '', punchingId, name, nights, monthNow]
+      );
+      await calculateSalaryForMonth(conn, empId, monthNow);
+      uploadedCount++;
+    }
+    await conn.commit();
+    req.flash('success', `Night data uploaded for ${uploadedCount} employees`);
+  } catch (err) {
+    await conn.rollback();
+    console.error('Error processing night data:', err);
+    req.flash('error', 'Failed to process night data');
+  } finally {
+    conn.release();
+  }
+
+  res.redirect('/operator/departments');
+});
+
+// GET night shift Excel template
+router.get('/salary/night-template', isAuthenticated, isOperator, async (req, res) => {
+  try {
+    const workbook = new ExcelJS.Workbook();
+    const sheet = workbook.addWorksheet('NightTemplate');
+    sheet.columns = [
+      { header: 'supervisorname', key: 'supervisorname', width: 20 },
+      { header: 'supervisordepartment', key: 'supervisordepartment', width: 20 },
+      { header: 'punchingid', key: 'punchingid', width: 15 },
+      { header: 'name', key: 'name', width: 20 },
+      { header: 'nights', key: 'nights', width: 10 },
+      { header: 'month', key: 'month', width: 12 }
+    ];
+    res.setHeader('Content-Disposition', 'attachment; filename="NightShiftTemplate.xlsx"');
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    await workbook.xlsx.write(res);
+    return res.end();
+  } catch (err) {
+    console.error('Error downloading night template:', err);
+    req.flash('error', 'Error downloading night template');
+    return res.redirect('/operator/departments');
+  }
 });
 
 // View salary summary for operator

--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -64,6 +64,17 @@
         <button type="submit" class="btn btn-primary">Upload</button>
       </div>
     </form>
+    <form action="/salary/upload-nights" method="POST" enctype="multipart/form-data" class="row g-3 mb-3">
+      <div class="col-md-6">
+        <input type="file" name="excelFile" accept=".xlsx,.xls" class="form-control" required>
+      </div>
+      <div class="col-md-2">
+        <button type="submit" class="btn btn-primary">Upload Nights</button>
+      </div>
+    </form>
+    <div class="mb-3">
+      <a href="/salary/night-template" class="btn btn-success">Download Night Template</a>
+    </div>
     <div class="table-responsive">
       <table class="table table-bordered">
         <thead>


### PR DESCRIPTION
## Summary
- support Excel download for night-shift uploads
- wire the template link on the operator dashboard
- document the download route in the README

## Testing
- `node -c helpers/salaryCalculator.js`
- `node -c routes/salaryRoutes.js`


------
https://chatgpt.com/codex/tasks/task_e_685fbadf3e6c832086512664a3eb25c0