### PR TITLE
Add sandwich day and Sunday deduction rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ Supervisors may override this by assigning a `paid_sunday_allowance` value for a
 specifies how many Sundays in a month are paid regardless of salary; additional worked Sundays become
 leave days.
 
+If an employee is absent on the Saturday before or the Monday after a Sunday, that Sunday is treated as an unpaid absence.
+
 The salary view lists each day's hours worked along with a note explaining any deductions, so supervisors
 can easily trace why pay was reduced.
 
@@ -272,4 +274,20 @@ Uploading a sheet increases the employee's salary by `nights * (salary / days_in
 
 Operators can download an Excel template for this upload via the `/salary/night-template` route. The file includes the following columns:
 `supervisorname`, `supervisordepartment`, `punchingid`, `name`, `nights`, `month`.
+
+## Sandwich Dates
+
+Create a table so operators can mark certain dates as "sandwich" days:
+
+```sql
+CREATE TABLE sandwich_dates (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  date DATE NOT NULL,
+  UNIQUE KEY uniq_sandwich (date)
+);
+```
+
+A sandwich day is normally a paid leave. However if an employee is absent either on the day before or the day after, the sandwich day becomes unpaid and is deducted from their salary.
+
+Salaries are released 15 days after the end of the month so that any deductions for damage or misconduct can be applied before payout.
 

--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -7,15 +7,52 @@ async function calculateSalaryForMonth(conn, employeeId, month) {
     'SELECT date, status FROM employee_attendance WHERE employee_id = ? AND DATE_FORMAT(date, "%Y-%m") = ?',
     [employeeId, month]
   );
+  const [sandwichRows] = await conn.query(
+    'SELECT date FROM sandwich_dates WHERE DATE_FORMAT(date, "%Y-%m") = ?',
+    [month]
+  );
   const daysInMonth = moment(month + '-01').daysInMonth();
   const dailyRate = parseFloat(emp.salary) / daysInMonth;
+  const sandwichDates = sandwichRows.map(r => moment(r.date).format('YYYY-MM-DD'));
+  const attMap = {};
+  attendance.forEach(a => {
+    attMap[moment(a.date).format('YYYY-MM-DD')] = a.status;
+  });
+
   let absent = 0;
   let extraPay = 0;
   let paidUsed = 0;
+
   attendance.forEach(a => {
+    const dateStr = moment(a.date).format('YYYY-MM-DD');
+    const status = a.status;
     const isSun = moment(a.date).day() === 0;
+    const isSandwich = sandwichDates.includes(dateStr);
+
     if (isSun) {
-      if (a.status === 'present') {
+      const satStatus = attMap[moment(a.date).subtract(1, 'day').format('YYYY-MM-DD')];
+      const monStatus = attMap[moment(a.date).add(1, 'day').format('YYYY-MM-DD')];
+      const adjAbsent = (satStatus === 'absent' || satStatus === 'one punch only') ||
+                        (monStatus === 'absent' || monStatus === 'one punch only');
+      if (adjAbsent) {
+        absent++;
+        return;
+      }
+    }
+
+    if (isSandwich) {
+      const prevStatus = attMap[moment(a.date).subtract(1, 'day').format('YYYY-MM-DD')];
+      const nextStatus = attMap[moment(a.date).add(1, 'day').format('YYYY-MM-DD')];
+      const adjAbsent = (prevStatus === 'absent' || prevStatus === 'one punch only') ||
+                        (nextStatus === 'absent' || nextStatus === 'one punch only');
+      if (adjAbsent) {
+        absent++;
+        return;
+      }
+    }
+
+    if (isSun) {
+      if (status === 'present') {
         if (parseFloat(emp.salary) < 13500) {
           extraPay += dailyRate;
         } else if (paidUsed < (emp.paid_sunday_allowance || 0)) {
@@ -24,7 +61,7 @@ async function calculateSalaryForMonth(conn, employeeId, month) {
         }
       }
     } else {
-      if (a.status === 'absent' || a.status === 'one punch only') absent++;
+      if (status === 'absent' || status === 'one punch only') absent++;
     }
   });
 


### PR DESCRIPTION
## Summary
- handle unpaid Sundays when Saturday or Monday is absent
- allow configuration of `sandwich` dates that become unpaid if an adjacent day is absent
- document new tables and salary rules

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685fcf0cb0b48320bb214f81c21b2b0c