### PR TITLE
Improve operator dashboard UI

### DIFF
--- a/views/operatorDashboard.ejs
+++ b/views/operatorDashboard.ejs
@@ -117,26 +117,27 @@
 </head>
 <body>
   <!-- Top Navigation Bar -->
-  <div class="top-nav d-flex justify-content-between align-items-center">
+  <header class="top-nav d-flex justify-content-between align-items-center" role="banner">
     <div class="nav-brand">Kotty Dashboard</div>
-    <button id="toggleDarkMode" class="btn btn-sm btn-outline-light">
-      <i class="bi bi-sun"></i>
+    <button id="toggleDarkMode" class="btn btn-sm btn-outline-light" aria-label="Toggle dark mode">
+      <i class="bi bi-sun" aria-hidden="true"></i>
+      <span class="visually-hidden">Toggle dark mode</span>
     </button>
-  </div>
+  </header>
 
   <!-- Sidebar -->
-  <nav id="sidebar" class="offcanvas-md offcanvas-start show">
-    <a href="/operator/dashboard" class="active"><i class="bi bi-speedometer2"></i> Dashboard</a>
-    <a href="/operator/editcuttinglots"><i class="bi bi-pencil-square"></i> Edit Lots</a>
-    <a href="/operator/dashboard/download-all-lots"><i class="bi bi-cloud-arrow-down"></i> Export All</a>
-    <a href="/search-dashboard"><i class="bi bi-search"></i> Search</a>
-    <a href="/assign-to-washing"><i class="bi bi-arrow-right-circle"></i> Washing</a>
-    <a href="/operator/dashboard/pic-report"><i class="bi bi-file-earmark-check"></i> PIC Report</a>
-    <a href="/operator/departments"><i class="bi bi-wallet2"></i> Salaries</a>
+  <nav id="sidebar" class="offcanvas-md offcanvas-start show" role="navigation" aria-label="Main navigation">
+    <a href="/operator/dashboard" class="active" aria-current="page"><i class="bi bi-speedometer2" aria-hidden="true"></i> Dashboard</a>
+    <a href="/operator/editcuttinglots"><i class="bi bi-pencil-square" aria-hidden="true"></i> Edit Lots</a>
+    <a href="/operator/dashboard/download-all-lots"><i class="bi bi-cloud-arrow-down" aria-hidden="true"></i> Export All</a>
+    <a href="/search-dashboard"><i class="bi bi-search" aria-hidden="true"></i> Search</a>
+    <a href="/assign-to-washing"><i class="bi bi-arrow-right-circle" aria-hidden="true"></i> Washing</a>
+    <a href="/operator/dashboard/pic-report"><i class="bi bi-file-earmark-check" aria-hidden="true"></i> PIC Report</a>
+    <a href="/operator/departments"><i class="bi bi-wallet2" aria-hidden="true"></i> Salaries</a>
   </nav>
 
   <!-- Main Content Area -->
-  <div id="mainContent" class="container-fluid">
+  <main id="mainContent" class="container-fluid">
     <div class="portal-header my-3">
       <h1>Kotty Operator Dashboard</h1>
       <p class="text-muted">Enhanced Production Overview</p>
@@ -261,32 +262,35 @@
         </div>
       </div>
       <div class="panel-body">
-        <input id="pendencySearchInput" type="text" class="form-control mb-2" placeholder="Search pendency...">
+        <input id="pendencySearchInput" type="text" class="form-control mb-2" placeholder="Search pendency..." aria-label="Search pendency">
         <div id="pendencyTable" style="height:400px;"></div>
-        <button id="loadMorePendency" class="btn btn-primary mt-2">Load More</button>
+        <button id="loadMorePendency" class="btn btn-primary mt-2" aria-label="Load more pendency results">Load More</button>
       </div>
-    </div>
   </div>
+  </main>
 
   <!-- Lot Details Modal -->
-  <div class="modal fade" id="lotDetailsModal" tabindex="-1">
+  <div class="modal fade" id="lotDetailsModal" tabindex="-1" aria-hidden="true" aria-labelledby="lotDetailsTitle">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title">Lot Details</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          <h5 id="lotDetailsTitle" class="modal-title">Lot Details</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
-        <div class="modal-body" id="lotDetailsBody">
+        <div class="modal-body" id="lotDetailsBody" aria-live="polite">
           Loading...
         </div>
       </div>
     </div>
   </div>
 
+  <!-- Back to Top Button -->
+  <button id="backToTop" class="btn btn-primary position-fixed" style="bottom:20px; right:20px; display:none;" aria-label="Back to top">&uarr; Top</button>
+
   <!-- Bootstrap & Tabulator JS -->
-  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" defer></script>
+  <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js" defer></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       // Dark Mode Toggle
@@ -378,6 +382,19 @@
       // Enable Bootstrap tooltips
       const tooltipList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
       tooltipList.forEach(el => new bootstrap.Tooltip(el));
+
+      // Back to top button
+      const backToTop = document.getElementById('backToTop');
+      window.addEventListener('scroll', () => {
+        if (window.scrollY > 200) {
+          backToTop.style.display = 'block';
+        } else {
+          backToTop.style.display = 'none';
+        }
+      });
+      backToTop.addEventListener('click', () => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- update operator dashboard navigation semantics
- improve accessibility attributes and add a back-to-top button
- defer JS assets

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685fe09ed8a883209c096f26c3f11a6a