### PR TITLE
Fix dihadi salary hours and restrict date range

### DIFF
--- a/routes/salaryRoutes.js
+++ b/routes/salaryRoutes.js
@@ -5,7 +5,7 @@ const path = require('path');
 const moment = require('moment');
 const { pool } = require('../config/db');
 const { isAuthenticated, isOperator, isSupervisor } = require('../middlewares/auth');
-const { calculateSalaryForMonth } = require('../helpers/salaryCalculator');
+const { calculateSalaryForMonth, effectiveHours } = require('../helpers/salaryCalculator');
 const { validateAttendanceFilename } = require('../helpers/attendanceFilenameValidator');
 const XLSX = require('xlsx');
 const ExcelJS = require('exceljs');
@@ -209,15 +209,26 @@ router.get('/employees/:id/salary', isAuthenticated, isSupervisor, async (req, r
       req.flash('error', 'Employee not found');
       return res.redirect('/supervisor/employees');
     }
-    const [attendance] = await pool.query('SELECT * FROM employee_attendance WHERE employee_id = ? AND DATE_FORMAT(date, "%Y-%m") = ? ORDER BY date', [empId, month]);
+    const startDate = moment(month + '-01').format('YYYY-MM-DD');
+    const endDate = moment(month + '-15').format('YYYY-MM-DD');
+    const [attendance] = await pool.query('SELECT * FROM employee_attendance WHERE employee_id = ? AND date BETWEEN ? AND ? ORDER BY date', [empId, startDate, endDate]);
     const daysInMonth = moment(month + '-01').daysInMonth();
     const dailyRate = parseFloat(emp.salary) / daysInMonth;
+    let totalHours = 0;
+    let hourlyRate = 0;
+    if (emp.salary_type === 'dihadi') {
+      hourlyRate = emp.allotted_hours
+        ? parseFloat(emp.salary) / parseFloat(emp.allotted_hours)
+        : 0;
+    }
     let paidUsed = 0;
     attendance.forEach(a => {
       if (a.punch_in && a.punch_out) {
-        const start = moment(a.punch_in, 'HH:mm:ss');
-        const end = moment(a.punch_out, 'HH:mm:ss');
-        a.hours = parseFloat((end.diff(start, 'minutes') / 60).toFixed(2));
+        const hrs = parseFloat(effectiveHours(a.punch_in, a.punch_out).toFixed(2));
+        a.hours = hrs;
+        if (emp.salary_type === 'dihadi') {
+          totalHours += hrs;
+        }
       } else {
         a.hours = 0;
       }
@@ -245,8 +256,11 @@ router.get('/employees/:id/salary', isAuthenticated, isSupervisor, async (req, r
         }
       }
     });
+    if (emp.salary_type === 'dihadi') {
+      totalHours = parseFloat(totalHours.toFixed(2));
+    }
     const [[salary]] = await pool.query('SELECT * FROM employee_salaries WHERE employee_id = ? AND month = ? LIMIT 1', [empId, month]);
-    res.render('employeeSalary', { user: req.session.user, employee: emp, attendance, salary, month, dailyRate });
+    res.render('employeeSalary', { user: req.session.user, employee: emp, attendance, salary, month, dailyRate, totalHours, hourlyRate });
   } catch (err) {
     console.error('Error loading salary view:', err);
     req.flash('error', 'Failed to load salary');

--- a/views/employeeSalary.ejs
+++ b/views/employeeSalary.ejs
@@ -55,6 +55,9 @@
       <% }) %>
     </tbody>
   </table>
+  <% if (employee.salary_type === 'dihadi') { %>
+    <h6>Total Hours: <%= totalHours %> | Hourly Pay: <%= hourlyRate.toFixed(2) %></h6>
+  <% } %>
   <% if (salary) { %>
     <h6>Gross: <%= salary.gross %> | Deduction: <%= salary.deduction %> | Net: <%= salary.net %></h6>
   <% } else { %>


### PR DESCRIPTION
## Summary
- implement `effectiveHours` helper with lunch deduction
- use first-half date range in `calculateDihadiMonthly`
- show deducted hours in employee salary view
- restrict salary views to days 1-15 only
- display dihadi total hours and hourly pay on salary page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68611a0ed4708320b9601c8aabf8a1e2