### PR TITLE
Fix export timing for salary calculator

### DIFF
--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -13,6 +13,7 @@ function effectiveHours(punchIn, punchOut) {
   if (hours < 0) hours = 0;
   return hours;
 }
+exports.effectiveHours = effectiveHours;
 
 async function calculateSalaryForMonth(conn, employeeId, month) {
   const [[emp]] = await conn.query(
@@ -123,4 +124,4 @@ async function calculateDihadiMonthly(conn, employeeId, month, emp) {
   );
 }
 
-module.exports = { calculateSalaryForMonth, effectiveHours };
+exports.calculateSalaryForMonth = calculateSalaryForMonth;


### PR DESCRIPTION
## Summary
- export helper functions directly via `exports` to avoid circular dependency warnings

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68612d6794248320a890a9367a82acfa