### PR TITLE
Fix export timing for salary calculator

### DIFF
--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -13,6 +13,17 @@ function effectiveHours(punchIn, punchOut) {
   if (hours < 0) hours = 0;
   return hours;
 }
+exports.effectiveHours = effectiveHours;
+
+function lunchDeduction(punchIn, punchOut) {
+  const start = moment(punchIn, 'HH:mm:ss');
+  const end = moment(punchOut, 'HH:mm:ss');
+  const mins = end.diff(start, 'minutes');
+  if (mins >= 11 * 60 + 50) return 50 / 60;
+  if (mins > 5 * 60 + 10) return 0.5;
+  return 0;
+}
+exports.lunchDeduction = lunchDeduction;
 
 async function calculateSalaryForMonth(conn, employeeId, month) {
   const [[emp]] = await conn.query(
@@ -123,4 +134,4 @@ async function calculateDihadiMonthly(conn, employeeId, month, emp) {
   );
 }
 
-module.exports = { calculateSalaryForMonth, effectiveHours };
+exports.calculateSalaryForMonth = calculateSalaryForMonth;

--- a/views/employeeSalary.ejs
+++ b/views/employeeSalary.ejs
@@ -39,6 +39,9 @@
         <th>Punch In</th>
         <th>Punch Out</th>
         <th>Hours</th>
+        <% if (employee.salary_type === 'dihadi') { %>
+          <th>Lunch Deduction</th>
+        <% } %>
         <th>Deduction Reason</th>
       </tr>
     </thead>
@@ -50,6 +53,9 @@
           <td><%= a.punch_in || '' %></td>
           <td><%= a.punch_out || '' %></td>
           <td><%= a.hours %></td>
+          <% if (employee.salary_type === 'dihadi') { %>
+            <td><%= a.lunch_deduction %></td>
+          <% } %>
           <td><%= a.deduction_reason %></td>
         </tr>
       <% }) %>


### PR DESCRIPTION
## Summary
- export helper functions directly via `exports` to avoid circular dependency warnings
- show lunch deduction in dihadi salary view

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68612d6794248320a890a9367a82acfa