### PR TITLE
Refine lunch deduction logic and time formatting

### DIFF
--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -1,18 +1,25 @@
 const moment = require('moment');
 
+function lunchDeduction(punchIn, punchOut) {
+  const start = moment(punchIn, 'HH:mm:ss');
+  const end = moment(punchOut, 'HH:mm:ss');
+  const mins = end.diff(start, 'minutes');
+  if (mins <= 5 * 60) return 0;
+  if (mins <= 9 * 60 + 30) return 30;
+  return 60;
+}
+exports.lunchDeduction = lunchDeduction;
+
 function effectiveHours(punchIn, punchOut) {
   const start = moment(punchIn, 'HH:mm:ss');
   const end = moment(punchOut, 'HH:mm:ss');
-  let hours = end.diff(start, 'minutes') / 60;
-  const mins = hours * 60;
-  if (mins >= 11 * 60 + 50) {
-    hours -= 50 / 60;
-  } else if (mins > 5 * 60 + 10) {
-    hours -= 0.5;
-  }
-  if (hours < 0) hours = 0;
-  return hours;
+  let mins = end.diff(start, 'minutes');
+  mins -= lunchDeduction(punchIn, punchOut);
+  if (mins > 11 * 60) mins = 11 * 60;
+  if (mins < 0) mins = 0;
+  return mins / 60;
 }
+exports.effectiveHours = effectiveHours;
 
 async function calculateSalaryForMonth(conn, employeeId, month) {
   const [[emp]] = await conn.query(
@@ -123,4 +130,4 @@ async function calculateDihadiMonthly(conn, employeeId, month, emp) {
   );
 }
 
-module.exports = { calculateSalaryForMonth, effectiveHours };
+exports.calculateSalaryForMonth = calculateSalaryForMonth;

--- a/views/employeeSalary.ejs
+++ b/views/employeeSalary.ejs
@@ -39,6 +39,9 @@
         <th>Punch In</th>
         <th>Punch Out</th>
         <th>Hours</th>
+        <% if (employee.salary_type === 'dihadi') { %>
+          <th>Lunch Deduction (mins)</th>
+        <% } %>
         <th>Deduction Reason</th>
       </tr>
     </thead>
@@ -50,13 +53,16 @@
           <td><%= a.punch_in || '' %></td>
           <td><%= a.punch_out || '' %></td>
           <td><%= a.hours %></td>
+          <% if (employee.salary_type === 'dihadi') { %>
+            <td><%= a.lunch_deduction %></td>
+          <% } %>
           <td><%= a.deduction_reason %></td>
         </tr>
       <% }) %>
     </tbody>
   </table>
   <% if (employee.salary_type === 'dihadi') { %>
-    <h6>Total Hours: <%= totalHours %> | Hourly Pay: <%= hourlyRate.toFixed(2) %></h6>
+    <h6>Total Hours: <%= totalHours || '0.00' %> | Hourly Pay: <%= hourlyRate.toFixed(2) %></h6>
   <% } %>
   <% if (salary) { %>
     <h6>Gross: <%= salary.gross %> | Deduction: <%= salary.deduction %> | Net: <%= salary.net %></h6>


### PR DESCRIPTION
## Summary
- calculate lunch deduction based on total worked hours
- cap daily effective hours at 11
- show hours in hh.mm format and lunch deduction in minutes

## Testing
- `npm test` *(fails: Missing script)*
- `node --check helpers/salaryCalculator.js`
- `node --check routes/salaryRoutes.js`


------
https://chatgpt.com/codex/tasks/task_e_68612d6794248320a890a9367a82acfa