### PR TITLE
Fix dispatch modal issues

### DIFF
--- a/routes/finishingRoutes.js
+++ b/routes/finishingRoutes.js
@@ -693,6 +693,14 @@ router.post('/dispatch/:id', isAuthenticated, isFinishingMaster, async (req, res
       }
     }
     const dispatchSizes = req.body.dispatchSizes || {};
+    const hasQty = Object.values(dispatchSizes).some(v => {
+      const n = parseInt(v, 10);
+      return !isNaN(n) && n > 0;
+    });
+    if (!hasQty) {
+      req.flash('error', 'No dispatch quantities provided.');
+      return res.redirect('/finishingdashboard');
+    }
     conn = await pool.getConnection();
     await conn.beginTransaction();
     const [[entry]] = await conn.query(`

--- a/views/finishingDashboard.ejs
+++ b/views/finishingDashboard.ejs
@@ -516,7 +516,8 @@
         const json = await resp.json();
         const rows = json.data || [];
         rows.forEach(entry => {
-          const dispatchBtnClass = entry.fullyDispatched ? 'btn-secondary' : 'btn-success';
+        const dispatchBtnClass = entry.fullyDispatched ? 'btn-secondary' : 'btn-success';
+        const disabled = entry.fullyDispatched ? 'disabled' : '';
           const tr = document.createElement('tr');
           tr.innerHTML = `
             <td>${entry.id}</td>
@@ -528,7 +529,7 @@
             <td>
               <a href="/finishingdashboard/challan/${entry.id}" target="_blank" class="btn btn-sm btn-info mb-1">Challan</a>
               <button class="btn btn-sm btn-warning mb-1" data-bs-toggle="modal" data-bs-target="#updateModal" data-entry-id="${entry.id}">Update</button>
-              <button class="btn btn-sm ${dispatchBtnClass} mb-1" data-bs-toggle="modal" data-bs-target="#dispatchModal" data-entry-id="${entry.id}">Dispatch</button>
+              <button class="btn btn-sm ${dispatchBtnClass} mb-1" ${disabled} data-bs-toggle="modal" data-bs-target="#dispatchModal" data-entry-id="${entry.id}">Dispatch</button>
             </td>
           `;
           finishingTableBody.appendChild(tr);
@@ -641,6 +642,7 @@
       document.getElementById('dispatchAlertContainer').innerHTML = '';
       destinationSelect.value = '';
       otherDestinationInput.value = '';
+      otherDestinationInput.classList.add('d-none');
       dispatchSubmitBtn.disabled = false;
       dispatchSubmitBtn.classList.remove('btn-secondary');
       dispatchSubmitBtn.classList.add('btn-primary');


### PR DESCRIPTION
## Summary
- hide custom destination input when modal opens
- disable dispatch button when a lot is fully dispatched
- validate dispatch quantities before inserting

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_68620faea6708320b769ccac827ec149