### PR TITLE
Fix Sunday pay rules for catalog/account/merchant

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ Update the `employees` table to store each worker's allotted hours per day:
 ALTER TABLE employees ADD COLUMN allotted_hours DECIMAL(4,2) NOT NULL DEFAULT 0;
 ```
 
+Lunch breaks are deducted from the recorded hours only for workers paid on a `dihadi` (daily wage) basis. Monthly salary employees keep their full punch duration.
+
 Add a `designation` field for each employee:
 
 ```sql
@@ -221,11 +223,13 @@ monthly salary.
 
 ### Sunday Attendance Rules
 
-Employees whose monthly salary is below 13,500 receive an extra day's pay for every Sunday they work.
-For employees earning 13,500 or more, working on a Sunday does not increase pay but instead grants a leave day.
-Supervisors may override this by assigning a `paid_sunday_allowance` value for a worker.  The allowance
+Employees whose monthly salary is below 13,500 receive an extra day's pay for every Sunday they work,
+unless their department is `catalog`, `account` or `merchant`. Workers from those departments always
+receive Sunday pay **and** still have the day credited to their leave balance whenever they are present.
+For employees earning 13,500 or more, working on a Sunday does not increase pay but instead grants a
+leave day. Supervisors may override this by assigning a `paid_sunday_allowance` value for a worker.  The allowance
 specifies how many Sundays in a month are paid regardless of salary; additional worked Sundays become
-leave days.
+leave days. These credited days are automatically stored in `employee_leaves` whenever salaries are recalculated.
 
 If an employee is absent on the Saturday before or the Monday after a Sunday, that Sunday is treated as an unpaid absence.
 

--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -1,6 +1,7 @@
 const moment = require('moment');
 
-function lunchDeduction(punchIn, punchOut) {
+function lunchDeduction(punchIn, punchOut, salaryType = 'dihadi') {
+  if (salaryType !== 'dihadi') return 0;
   const out = moment(punchOut, 'HH:mm:ss');
   const firstCut = moment('13:10:00', 'HH:mm:ss');
   const secondCut = moment('18:10:00', 'HH:mm:ss');
@@ -10,11 +11,11 @@ function lunchDeduction(punchIn, punchOut) {
 }
 exports.lunchDeduction = lunchDeduction;
 
-function effectiveHours(punchIn, punchOut) {
+function effectiveHours(punchIn, punchOut, salaryType = 'dihadi') {
   const start = moment(punchIn, 'HH:mm:ss');
   const end = moment(punchOut, 'HH:mm:ss');
   let mins = end.diff(start, 'minutes');
-  mins -= lunchDeduction(punchIn, punchOut);
+  mins -= lunchDeduction(punchIn, punchOut, salaryType);
   if (mins > 11 * 60) mins = 11 * 60;
   if (mins < 0) mins = 0;
   return mins / 60;
@@ -25,10 +26,22 @@ exports.effectiveHours = effectiveHours;
 
 async function calculateSalaryForMonth(conn, employeeId, month) {
   const [[emp]] = await conn.query(
-    'SELECT salary, salary_type, paid_sunday_allowance, allotted_hours FROM employees WHERE id = ?',
+    `SELECT e.salary, e.salary_type, e.paid_sunday_allowance, e.allotted_hours,
+            d.name AS department
+       FROM employees e
+       LEFT JOIN (
+             SELECT user_id, MIN(department_id) AS department_id
+               FROM department_supervisors
+              GROUP BY user_id
+       ) ds ON ds.user_id = e.supervisor_id
+       LEFT JOIN departments d ON ds.department_id = d.id
+      WHERE e.id = ?`,
     [employeeId]
   );
   if (!emp) return;
+  const specialDept = ['catalog', 'account', 'merchant'].includes(
+    (emp.department || '').toLowerCase()
+  );
   if (emp.salary_type === 'dihadi') {
     await calculateDihadiMonthly(conn, employeeId, month, emp);
     return;
@@ -52,6 +65,7 @@ async function calculateSalaryForMonth(conn, employeeId, month) {
   let absent = 0;
   let extraPay = 0;
   let paidUsed = 0;
+  const creditLeaves = [];
 
   attendance.forEach(a => {
     const dateStr = moment(a.date).format('YYYY-MM-DD');
@@ -83,17 +97,35 @@ async function calculateSalaryForMonth(conn, employeeId, month) {
 
     if (isSun) {
       if (status === 'present') {
-        if (parseFloat(emp.salary) < 13500) {
+        if (specialDept) {
+          extraPay += dailyRate;
+          creditLeaves.push(dateStr);
+        } else if (parseFloat(emp.salary) < 13500) {
           extraPay += dailyRate;
         } else if (paidUsed < (emp.paid_sunday_allowance || 0)) {
           extraPay += dailyRate;
           paidUsed++;
+        } else {
+          creditLeaves.push(dateStr);
         }
       }
     } else {
       if (status === 'absent' || status === 'one punch only') absent++;
     }
   });
+
+  for (const d of creditLeaves) {
+    const [rows] = await conn.query(
+      'SELECT id FROM employee_leaves WHERE employee_id = ? AND leave_date = ?',
+      [employeeId, d]
+    );
+    if (!rows.length) {
+      await conn.query(
+        'INSERT INTO employee_leaves (employee_id, leave_date, days, remark) VALUES (?, ?, 1, ?)',
+        [employeeId, d, 'Sunday Credit']
+      );
+    }
+  }
 
   const [nightRows] = await conn.query(
     'SELECT COALESCE(SUM(nights),0) AS total_nights FROM employee_nights WHERE employee_id = ? AND month = ?',


### PR DESCRIPTION
## Summary
- compute each employee's department when calculating salary
- credit leave and pay Sunday simultaneously for catalog, account or merchant staff
- update salary view deduction reasons
- document special department Sunday policy

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686224bc8e88832081c8cedf21e8b3f1