### PR TITLE
Implement sandwich weekend absence rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ specifies how many Sundays in a month are paid regardless of salary; additional 
 leave days. These credited days are automatically stored in `employee_leaves` whenever salaries are recalculated.
 
 
-If an employee is absent on the Saturday before or the Monday after a Sunday, that Sunday is treated as an unpaid absence.
+If an employee is absent on the Saturday before or the Monday after a Sunday, that Sunday is treated as an unpaid absence. When both the Saturday and the following Monday are missed, the weekend becomes a "sandwich" and all three days—Saturday, Sunday and Monday—are deducted from the employee's salary.
 
 The salary view lists each day's hours worked along with a note explaining any deductions, so supervisors
 can easily trace why pay was reduced.

--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -75,11 +75,11 @@ async function calculateSalaryForMonth(conn, employeeId, month) {
     const isSandwich = sandwichDates.includes(dateStr);
 
     if (isSun) {
-      const satStatus = attMap[moment(a.date).subtract(1, 'day').format('YYYY-MM-DD')];
-      const monStatus = attMap[moment(a.date).add(1, 'day').format('YYYY-MM-DD')];
-      const adjAbsent = (satStatus === 'absent' || satStatus === 'one punch only') ||
-                        (monStatus === 'absent' || monStatus === 'one punch only');
-      if (adjAbsent) {
+      const satStatus = attMap[moment(a.date).subtract(1, 'day').format('YYYY-MM-DD')] || 'absent';
+      const monStatus = attMap[moment(a.date).add(1, 'day').format('YYYY-MM-DD')] || 'absent';
+      const missedSat = satStatus === 'absent' || satStatus === 'one punch only';
+      const missedMon = monStatus === 'absent' || monStatus === 'one punch only';
+      if (missedSat || missedMon) {
         absent++;
         return;
       }

--- a/routes/departmentMgmtRoutes.js
+++ b/routes/departmentMgmtRoutes.js
@@ -207,8 +207,8 @@ router.get('/departments/salary/download', isAuthenticated, isOperator, async (r
         const isSun = moment(a.date).day() === 0;
         const isSandwich = sandwichDates.includes(dateStr);
         if (isSun) {
-          const satStatus = attMap[moment(a.date).subtract(1, 'day').format('YYYY-MM-DD')];
-          const monStatus = attMap[moment(a.date).add(1, 'day').format('YYYY-MM-DD')];
+          const satStatus = attMap[moment(a.date).subtract(1, 'day').format('YYYY-MM-DD')] || 'absent';
+          const monStatus = attMap[moment(a.date).add(1, 'day').format('YYYY-MM-DD')] || 'absent';
           const adjAbsent = (satStatus === 'absent' || satStatus === 'one punch only') ||
                             (monStatus === 'absent' || monStatus === 'one punch only');
           if (adjAbsent) {


### PR DESCRIPTION
## Summary
- clarify Sunday sandwich absences in README
- treat missing adjacent-day attendance as absent when checking Sunday absences
- apply same logic in department salary export

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68623a84acd88320a47d93ca668eeb5e